### PR TITLE
Support for Extensions, Complete Headers and Multiple HDUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/_build/*
 test.py
 pyproject.toml
 dist-newstyle/
+.nvim.lua

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ fits-parse.cabal
 .stack-work/
 docs/_build/*
 .liquid/
+.python-version
+test.py
+pyproject.toml
+dist-newstyle/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test.py
 pyproject.toml
 dist-newstyle/
 .nvim.lua
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ docs/_build/*
 test.py
 pyproject.toml
 dist-newstyle/
+tags
 .nvim.lua
 .DS_Store
+hls.json

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/fits_files/nso_dkist.fits
+++ b/fits_files/nso_dkist.fits
@@ -1,0 +1,581 @@
+SIMPLE  =                    T / conforms to FITS standard                      BITPIX  =                    8 / array data type                                NAXIS   =                    0 / number of array dimensions                     EXTEND  =                    T                                                  CHECKSUM= 'D6bEF3a9D3aCD3a9'   / HDU checksum updated 2023-04-22T04:10:59       DATASUM = '0       '           / data unit checksum updated 2023-04-22T04:10:59 END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             XTENSION= 'BINTABLE'           / binary table extension                         BITPIX  =                    8 / array data type                                NAXIS   =                    2 / number of array dimensions                     NAXIS1  =                   32 / width of table in bytes                        NAXIS2  =                  998 / number of rows in table                        PCOUNT  =                95968 / number of group parameters                     GCOUNT  =                    1 / number of groups                               TFIELDS =                    4 / number of fields in each row                   TTYPE1  = 'COMPRESSED_DATA'    / label for field 1                              TFORM1  = '1PB(114)'           / data format of field: variable length array    TTYPE2  = 'GZIP_COMPRESSED_DATA' / label for field 2                            TFORM2  = '1PB(0)  '           / data format of field: variable length array    TTYPE3  = 'ZSCALE  '           / label for field 3                              TFORM3  = '1D      '           / data format of field: 8-byte DOUBLE            TTYPE4  = 'ZZERO   '           / label for field 4                              TFORM4  = '1D      '           / data format of field: 8-byte DOUBLE            ZIMAGE  =                    T / extension contains compressed image            ZTENSION= 'IMAGE   '                                                            ZBITPIX =                  -64                                                  ZNAXIS  =                    3                                                  ZNAXIS1 =                  100 / [pix]                                          ZNAXIS2 =                  998 / [pix]                                          ZNAXIS3 =                    1 / [pix]                                          ZPCOUNT =                    0                                                  ZGCOUNT =                    1                                                  ZTILE1  =                  100 / size of tiles to be compressed                 ZTILE2  =                    1 / size of tiles to be compressed                 ZTILE3  =                    1 / size of tiles to be compressed                 ZCMPTYPE= 'RICE_1  '           / compression algorithm                          ZNAME1  = 'BLOCKSIZE'          / compression block size                         ZVAL1   =                   32 / pixels per block                               ZNAME2  = 'BYTEPIX '           / bytes per pixel (1, 2, 4, or 8)                ZVAL2   =                    4 / bytes per pixel (1, 2, 4, or 8)                ZNAME3  = 'NOISEBIT'           / floating point quantization level              ZVAL3   =                 16.0 / floating point quantization level              ZQUANTIZ= 'NO_DITHER'          / No dithering during quantization               BUNIT   = 'ct      '                                                            DATE    = '2023-04-22T04:10:58.392'                                             DATE-BEG= '2022-06-03T18:34:29.559'                                             DATE-END= '2022-06-03T18:34:29.825'                                             TELAPSE =   0.2660001162439585 / [s]                                            DATE-AVG= '2022-06-03T18:34:29.692000'                                          ORIGIN  = 'National Solar Observatory'                                          TELESCOP= 'Daniel K. Inouye Solar Telescope'                                    OBSRVTRY= 'Haleakala High Altitude Observatory Site'                            NETWORK = 'NSF-DKIST'                                                           INSTRUME= 'VISP    '                                                            OBJECT  = 'unknown '                                                            CHECKSUM= '9kg8Akd53kd59kd5'   / HDU checksum updated 2023-04-22T04:10:59       DATASUM = '2081763389'         / data unit checksum updated 2023-04-22T04:10:59                                                                                 COMMENT ------------------------------ Telescope -------------------------------COMMENT  Keys describing the pointing and operation of the telescope. Including COMMENT     the FITS WCS keys describing the world coordinates of the array.    COMMENT ------------------------------------------------------------------------WCSAXES =                    3                                                  WCSAXESA=                    3                                                  WCSNAME = 'Helioprojective-cartesian'                                           WCSNAMEA= 'Equatorial equinox J2000'                                            CRPIX1  =   -82.86774961586269 / [pix]                                          CRPIX2  =                499.0 / [pix]                                          CRPIX3  =    26.91207092114994 / [pix]                                          CRPIX1A =   -82.86778489684515 / [pix]                                          CRPIX2A =                499.0 / [pix]                                          CRPIX3A =    26.90673195834938 / [pix]                                          CRVAL1  =              854.231                                                  CRVAL2  =   -378.0016001773252                                                  CRVAL3  =   -310.0099922384685                                                  CRVAL1A =              854.231                                                  CRVAL2A =    22.25861366077565                                                  CRVAL3A =    71.54760640717045                                                  CDELT1  = 0.000999811469978602                                                  CDELT2  =   0.2134568481952311                                                  CDELT3  =   0.2134568481952311                                                  CDELT1A = 0.000999811469978602                                                  CDELT2A = 5.92935689431197E-05                                                  CDELT3A = 5.92935689431197E-05                                                  CUNIT1  = 'nm      '                                                            CUNIT2  = 'arcsec  '                                                            CUNIT3  = 'arcsec  '                                                            CUNIT1A = 'nm      '                                                            CUNIT2A = 'deg     '                                                            CUNIT3A = 'deg     '                                                            CTYPE1  = 'AWAV    '                                                            CTYPE2  = 'HPLT-TAN'                                                            CTYPE3  = 'HPLN-TAN'                                                            CTYPE1A = 'AWAV    '                                                            CTYPE2A = 'DEC--TAN'                                                            CTYPE3A = 'RA---TAN'                                                            PC1_1   =    7.607822604906501                                                  PC1_2   =                  0.0                                                  PC1_3   = -0.00036747296713833                                                  PC2_1   =  0.03258800664428634                                                  PC2_2   =                  0.0                                                  PC2_3   =  0.09119427316600115                                                  PC3_1   =                  0.0                                                  PC3_2   =    1000.188565571669                                                  PC3_3   =                  0.0                                                  PC1_1A  =   -7.376733469625965                                                  PC1_2A  =                  0.0                                                  PC1_3A  = -0.02244171841344273                                                  PC2_1A  =   -1.864093831036593                                                  PC2_2A  =                  0.0                                                  PC2_3A  =   0.0883351211080864                                                  PC3_1A  =                  0.0                                                  PC3_2A  =    1000.188565571669                                                  PC3_3A  =                  0.0                                                  LONPOLE =                180.0 / [deg]                                          LONPOLEA=                180.0 / [deg]                                          TAZIMUTH=    76.35481766529557 / [deg] RawTelescopeAzimuthAngle                 ELEV_ANG=    36.54532962098321 / [deg] RawTelescopeElevationAngle               TELTRACK= 'Standard Differential Rotation Tracking' / TelescopeTrackingMode     TTBLANGL=    197.0144008687807 / [deg] TelescopeCoudeTableAngle                 TTBLTRCK= 'Fixed coude table angle' / TelescopeCoudeTableTrackingMode           DATEREF = '2022-06-03T18:34:29.559'                                             OBSGEO-X=   -5466045.256954942 / [m]                                            OBSGEO-Y=   -2404388.737412784 / [m]                                            OBSGEO-Z=    2242133.887690042 / [m]                                            SPECSYS = 'TOPOCENT'                                                            VELOSYS =                  0.0                                                  OBS_VR  =   -94.64534176238249 / [m s-1]                                        WCSVALID=                    T / WCSValidityIndicator                                                                                                           COMMENT ------------------------------ Datacenter ------------------------------COMMENT      Keys generated by the DKIST data center to describe processing     COMMENT                 performed, archiving or extra metadata.                 COMMENT ------------------------------------------------------------------------DSETID  = 'BQKZZ   '                                                            POINT_ID= 'BQKZZ   '                                                            FRAMEVOL=     2.27700138092041 / [Mbyte]                                        PROCTYPE= 'L1      '                                                            RRUNID  =                  578                                                  RECIPEID=                    1                                                  RINSTID =                  350                                                  EXTNAME = 'observation'                                                         SOLARNET=                    1                                                  OBS_HDU =                    1                                                  FILENAME= 'VISP_2022_06_03T18_34_29_559_00854231_I_BQKZZ_L1.fits'               CADENCE =   0.3282829148595638 / [s]                                            CADMIN  =  0.02399992942810059 / [s]                                            CADMAX  =    3.071000099182129 / [s]                                            CADVAR  =    0.834011691783927 / [s]                                            LEVEL   =                    1                                                  HEADVERS= '3.5.0   '                                                            HEAD_URL= 'https://docs.dkist.nso.edu/projects/data-products/en/v3.5.0'         INFO_URL= 'https://docs.dkist.nso.edu'                                          CALVERS = '2.0.1   '                                                            CAL_URL = 'https://docs.dkist.nso.edu/projects/visp/en/v2.0.1/l0_to_l1_visp.ht&'CONTINUE  'ml'                                                                  IDSPARID=                  409                                                  IDSOBSID=                  444                                                  IDSCALID=                  434                                                  WKFLNAME= 'l0_to_l1_visp'                                                       WKFLVERS= '2.0.1   '                                                                                                                                            COMMENT ------------------------------- Dataset --------------------------------COMMENT     Keys describing the dataset that this FITS file forms a part of.    COMMENT ------------------------------------------------------------------------DNAXIS  =                    4                                                  DNAXIS1 =                 2538 / [pix]                                          DNAXIS2 =                  998 / [pix]                                          DNAXIS3 =                  490 / [pix]                                          DNAXIS4 =                    4 / [pix]                                          DTYPE1  = 'SPECTRAL'                                                            DTYPE2  = 'SPATIAL '                                                            DTYPE3  = 'SPATIAL '                                                            DTYPE4  = 'STOKES  '                                                            DPNAME1 = 'dispersion axis'                                                     DPNAME2 = 'spatial along slit'                                                  DPNAME3 = 'raster scan step number'                                             DPNAME4 = 'polarization state'                                                  DWNAME1 = 'wavelength'                                                          DWNAME2 = 'helioprojective latitude'                                            DWNAME3 = 'helioprojective longitude'                                           DWNAME4 = 'polarization state'                                                  DUNIT1  = 'nm      '                                                            DUNIT2  = 'arcsec  '                                                            DUNIT3  = 'arcsec  '                                                            DUNIT4  = ''                                                                    DAAXES  =                    2                                                  DEAXES  =                    2                                                  DINDEX3 =                  490 / [pix]                                          DINDEX4 =                    1 / [pix]                                          LINEWAV =              854.231                                                  WAVEBAND= 'Ca II (854.21 nm)'                                                   WAVEUNIT=                   -9                                                  WAVEREF = 'Air     '                                                            WAVEMIN =    854.3138521265572 / [nm]                                           WAVEMAX =    856.8513736373629 / [nm]                                                                                                                           COMMENT ------------------------------ Statistics ------------------------------COMMENT   Statistical information about the data array contained in this FITS   COMMENT                                  file.                                  COMMENT ------------------------------------------------------------------------DATAMIN =  0.05511225546976106                                                  DATAMAX =    1.069711649853424                                                  DATAMEAN=   0.7919474769881233                                                  DATAMEDN=   0.8430040919513452                                                  DATARMS =   0.8080610568147634                                                  DATAKURT=    2.335709959309551                                                  DATASKEW=   -1.477126138763325                                                                                                                                  COMMENT ------------------------------- DKIST ID -------------------------------COMMENT  Unique identifiers for this FITS file and the observation that created COMMENT                                the data.                                COMMENT ------------------------------------------------------------------------FILE_ID = '94ba9c5fbadf4f26baef48809f9b2ff3' / FileID                           DKISTVER= 'Data Model (SPEC-0122) Revision E' / DKISTFITSHeaderVersion          OBSPR_ID= 'eid_1_118_opAvoqBr_R002.82591.14499687' / ObservingProgramExecutionIDEXPER_ID= 'eid_1_118'          / ExperimentID                                   PROP_ID = 'pid_1_118'          / ProposalID                                     DSP_ID  = 'eid_1_118_opAvoqBr_R002_ipM6wwxZ_dspCtVjmC' / DataSetParametersID    IP_ID   = 'id.85572.341432'    / InstrumentProgramExecutionID                   HLSVERS = 'Alakai_5-1'         / DKISTSoftwareVersion                           NPROPOS =                    1                                                  PROPID01= 'pid_1_118'                                                           NEXPERS =                    1                                                  EXPRID01= 'eid_1_118'                                                                                                                                           COMMENT --------------------------- DKIST Operations ---------------------------COMMENT    Information about this configuration or operations of the facility   COMMENT                        when generating this data.                       COMMENT ------------------------------------------------------------------------OCS_CTRL= 'Auto    '           / OCSControl                                     FIDO_CFG= 'OUT_C-M1_C-BS555_C-BS950_C-W1_C-W3' / FIDOConfiguration              DSHEALTH= 'GOOD    '           / DataSourceHealthStatus                         DSPSREPS=                    1 / DSPSNumberOfRepeats                            DSPSNUM =                    1 / DSPSRepeatNumber                               LIGHTLVL=    448.6954002173126 / [adu] LightLevel                                                                                                               COMMENT -------------------------------- Camera --------------------------------COMMENT        Keys describing modes and operation of the camera(s) used.       COMMENT ------------------------------------------------------------------------CAM_ID  = '15:VSC-04533'       / CameraUniqueID                                 CAMERA  = 'AndorZyla.03'       / CameraName                                     BITDEPTH=                   16 / SensBitsPerPixel                               XPOSURE =    48.00811267605634 / [ms] FPAExposureTime                           TEXPOSUR=    4.000676056338028 / [ms] CamExposureTime                           CAM_FPS =    41.35716748837339 / [Hz] CamFrameRate                              CHIPDIM1=                 2560 / [pix] ChipDimensionX                           CHIPDIM2=                 2160 / [pix] ChipDimensionY                           HWBIN1  =                    1 / [pix] HardwareBinningX                         HWBIN2  =                    1 / [pix] HardwareBinningY                         SWBIN1  =                    1 / [pix] SoftwareBinningX                         SWBIN2  =                    1 / [pix] SoftwareBinningY                         NSUMEXP =                   12 / NumRawFramesinFPA                              SWNROI  =                    1 / NumOfSWROI                                     SWROI1OX=                    0 / [pix] SWROI1OriginX                            SWROI1OY=                    0 / [pix] SWROI1OriginY                            SWROI1SX=                 2560 / [pix] SWROI1SizeX                              SWROI1SY=                 2000 / [pix] SWROI1SizeY                              HWNROI  =                    2 / NumOfHWROI                                     HWROI1OX=                    0 / [pix] HWROI1OriginX                            HWROI1OY=                    0 / [pix] HWROI1OriginY                            HWROI1SX=                 2560 / [pix] HWROI1SizeX                              HWROI1SY=                 1000 / [pix] HWROI1SizeY                              HWROI2OX=                    0 / [pix] HWROI2OriginX                            HWROI2OY=                 1160 / [pix] HWROI2OriginY                            HWROI2SX=                 2560 / [pix] HWROI2SizeX                              HWROI2SY=                 1000 / [pix] HWROI2SizeY                              NBIN1   =                    1                                                  NBIN2   =                    1                                                  NBIN3   =                    1                                                  NBIN    =                    1                                                  FPABITPX=                   20 / FPABitsPerPixel                                                                                                                COMMENT ---------------- Polarization Analysis and Calibration -----------------COMMENT  Keys describing the configuration of the Gregorian Optical System (GOS)COMMENT                                                                         COMMENT ------------------------------------------------------------------------GOS_STAT= 'open    '           / Upper GOS shutter                              LVL3STAT= 'clear   '           / Level 3 (Lamp)                                 LAMPSTAT= 'none    '           / Lamp status                                    LVL2STAT= 'clear   '           / Level 2 (Polarizer)                            POLANGLE= 'none    '           / [deg] Polarizer Angle                          LVL1STAT= 'clear   '           / Level 1 (Retarder)                             RETANGLE= 'none    '           / [deg] Retarder angle                           LVL0STAT= 'FieldStop (2.8arcmin)' / Level 0 (Apeture)                           APERTURE= '2.8arcmin'          / [arcmin, arcsec, mm] Aperture Property         LGOSSTAT= 'open    '           / Lower GOS shutter                              GOS_TEMP=    16.70166015625001 / [C] Upper GOS optics temperature                                                                                               COMMENT --------------------------- Adaptive Optics ----------------------------COMMENT          Keys describing aspects of the adaptive optics system.         COMMENT ------------------------------------------------------------------------ATMOS_R0=   0.1116264892989071 / [m] HOAOFriedParameter                         AO_LOCK =                    T / HOAOLockStatus                                 AO_LOCKX=                  0.0 / [arcsec] HOAOLockOffPointingX                  AO_LOCKY=                  0.0 / [arcsec] HOAOLockOffPointingY                  WFSLOCKX=                  0.0 / [arcsec] LOWFSLockOffPointingX                 WFSLOCKY=                  0.0 / [arcsec] LOWFSLockOffPointingY                 LIMBRPOS=                  0.0 / [arcsec] LimbSensorRadialSetPos                LIMBRATE=               1000.0 / [Hz] LimbSensorRate                                                                                                            COMMENT --------------------------- Weather Station ----------------------------COMMENT    Keys describing information reported by the weather station at the   COMMENT                    facility during this observation.                    COMMENT ------------------------------------------------------------------------WSSOURCE= 'dkist   '           / WeathSource                                    WIND_SPD=    4.958944660448225 / [m s-1] WeathWindSpeed                         WIND_DIR=    219.0563882913457 / [deg] WeathWindDirection                       WS_TEMP =    11.95233890933754 / [C] WeathOutsideTemperature                    WS_HUMID=    14.39925363345676 / [10**-2] WeathRelativeHumidity                 WS_DEWPT=   -16.21179492029672 / [C] WeathDewPoint                              WS_PRESS=    710.0214144384906 / [hPa] WeathBarometricPressure                  SKYBRIGT=                 -1.0 / WeathSkyBrightness                                                                                                             COMMENT --------------------------- VISP Instrument ----------------------------COMMENT          Keys specific to the operation of the VISP instrument.         COMMENT ------------------------------------------------------------------------VSPARMID=                    3 / ArmID                                          VSPARMPS=             -20.0786 / [deg] ArmPosition                              VSPARMFC=               54.127 / [mm] ArmFocus                                  VSPFILT = 'FF01-857_30-25'     / FilterID                                       VSPFWVLN=              856.229 / [nm] FilterWavelength                          VSPPOLMD= 'observe_polarimetric' / PolarimeterMode                              VSPMODID= '0004    '           / ModulatorID                                    VSPMOD  = 'continuous'         / ModulationType                                 VSPEXPRT=        41.3571674884 / [Hz] ExposureRate                              VSPGRTID= 'Newport_316.0_63.40__M20160612_SN3' / GratingID                      VSPGRTCN=                316.0 / [mm-1] GratingConstant                         VSPGRTBA=                 63.4 / [deg] GratingBlazeAngle                        VSPGRTAN=   -65.36539999999999 / [deg] GratingAngle                             VSPWID  =               0.2142 / [arcsec] SlitWidth                             VSPSLTSS=       0.132675941182 / [mm] SlitSteppingSize                          VSPNSTP =                  490 / NumberofSpatialSteps                           VSPSTP  =                  489 / CurrentSpatialStep                             VSPTPOS =    82.81485000000001 / [mm] SlitTranslationPosition                   VSPMIRPS=              39.2904 / [mm] FoldMirrorPosition                        VSPSPOS =                12.15 / [mm] SlitSelectorPosition                      VSPNMAPS=                    1 / TotalMapScans                                  VSPMAP  =                    1 / CurrentMapScan                                 ZHECKSUM= 'UMSGaMQFVMQFaMQF'   / HDU checksum updated 2023-04-22T04:10:59       ZDATASUM= '550335088'          / data unit checksum updated 2023-04-22T04:10:59 END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                \            ?}„¼N€Ë?ìTIYM¦   _   \        ?¡½,ù¸?ìB2
+l.   c   »        ?¿“±kG?ì®T   _          ?g¨ýd–p?ìë2Ïo   a  }        ?É°=œ6É?ì'÷ðœØ   a  Þ        ?³W	³Äƒ?ì:üÿU   b  ?        ?„X›o?ì8§Š³JÅ   a  ¡        ?¥¼¨únÂ?ì\ò)°„   f          ??ˆ)Ô?ìd9–èw   a  h        ?ýŠÒ>Á1?ìmÙ4(B   g  É        ?gèªH'å?ìy©›²”þ   d  0        ?+·}ÓÓ?ìrèïý‰8   \  ”        ?ß‹ü†¹?ìrqÍ–—   ]  ð        ?è…õ¸vú?ìdÞWú»   b  M        ?UXûƒÀ?ìbÓ¬ÛH…   b  ¯        ?‘òcTÁÿ?ìnk$ï-Ý   e          ?L³èÕzù?ì_c®§?   `  v        ?˜¬€f?ì`6cÔ¥   \  Ö        ?A“<½½Ü?ìj’e`¨´   `  2        ?g¨ýd—¦?ìrèïý‰”   `  ’        ?g¨ýd—¦?ìuUå6'   ^  ò        ?£š|õ[Ê?ìo+ Â
+q   c  P        ?G¾šÉÁÅ?ìˆ%†3     a  ³        ?[ˆàop©?ì†£4='¥   a  	        ?v½¡âù?ìˆ-_úÇ   `  	u        ?¥¼¨úox?ì–©àg2   d  	Õ        ?Àñjm}?ì’„‡G“i   `  
+9        ?[ˆàoq?ì–Š·,4   ]  
+™        ?ß‹ü†¹?ì–ÒHÏ   a  
+ö        ?˜"HA"?ì›1Þ/H   b  W        ?:$:n%?ì p…qmý   d  ¹        ?¿“±j7?ì–ôÃ¢,W   ^          ?6¥]HÈ?ì£ÍÃ÷<   ^  {        ?Š‡ç‡Ç'?ìœ¨Ó¿¾   `  Ù        ?É°=œ5“?ì¨_àBZ   d  9        ?Åæ¸xÔá?ìŸÕ<We   c          ?ú³Ý¸%?ìšS@>«   ^           ?ïxÇõ?ì©ÑÄ#DÊ   ^  ^        ?¡½,ù¸?ì¢¼[2b   \  ¼        ?oS&Œ?ì—oÈZý   _          ?Uär5?ì”k7Q_   e  w        ?}„¼N•?ìŸâ†S|¹   c  Ü        ?ú³Ý¸%?ì•'
+õ)   _  ?        ?g¨ýd—¦?ì—KLØ¦0   \  ž        ?¹†î ¥?ì“:SG   ^  ú        ?6¥]HÉJ?ì‘{–çný   a  X        ?Àñjm]?ì0Z›‰   ^  ¹        ?Ôž*&?ì†ÿ=ëÖ   d          ?¹v;ßF&?ì†WÝíô   `  {        ?g¨ýd˜Û?ì‡‡ŠÆ;   d  Û        ?Ó2'q?ì‚tÅ    a  ?        ?ú³Ý¸ï?ì†)É¨ò   \           ?r–ÜÙŒ8?ì‚Í€ºf‡   b  ü        ??ˆ+>?ì¹dÑ=Ä   c  ^        ??ˆ(i?ì”2gV   a  Á        ?ÀñjmØ?ì‰
+   \  "        ?r–ÜÙn?ìB`ß»”   c  ~        ?¸LW¿ƒ¼?ìu8<t%   ^  á        ?6¥]HÈ?ì¢»[   `  ?        ?„X›lô?ìŠÃç?ç   c  Ÿ        ?UXûƒ?ìŠ!
+ø|   `          ?g¨ýd–p?ì}Ó?b   a  b        ?G¾šÉÁÅ?ì„]Ô#þ   a  Ã        ?Î‹Ë&mˆ?ì‚\¡YïL   [  $        ?«ìæÉª?ì„vrÓPb   `          ?v½¡â	?ìtŽïãü0   _  ß        ?v½¡âT?ì|,í¾ó   b  >        ?¹v;ßF&?ìtòªac   c           ?ZNIŽÐ^?ìw½=G
+   `          ?„X›k‰?ìnØúûUä   _  c        ?,‰ÙW;?ìtPq°ìA   a  Â        ?v½¡âž?ìf"+½]   ^  #        ?g¨ýd˜Û?ì}Ó?ï   a          ??ˆ)Ô?ìsÙ#¬…'   e  â        ?
+üP;^$?ì{—ÞéY0   g  G        ?uƒ{*?ìx:9­-   d  ®        ?}|âÝ?ì}¬oºÇ   b          ?¹v;ßF&?ì…Ü+þw   `  t        ?i#A(Ã“?ìƒ¢YçñÌ   b  Ô        ??ˆ&þ?ìƒx°p¥   b  6        ?¿“±jì?ìyÇèf|   d  ˜        ?UXûƒ?ìqZ·Yý   a  ü        ?³W	³Äƒ?ìmoGW­²   `  ]        ?G¾šÉÁÅ?ìn9èJÑ}   f  ½        ?	„üÐÐN?ìdÍLÕŠ·   _   #        ?ïxÉ?ìRkcïXì   c   ‚        ?¸LW¿€æ?ìP $Rn   `   å        ?˜¬€g7?ìEzë±¤ê   ]  !E        ?ïxÉ?ìCõ'Ð§„   a  !¢        ?¿“±j’?ì>íkòz¹   _  "        ?âVÌñ?ìG…CA¤   `  "b        ?ýŠÒ>Â÷?ìJBœ<Ñv   d  "Â        ?}|åI?ìP1{¨5`   d  #&        ?}|åI?ìV%j   ]  #Š        ?¡½,ø‚?ì[(º|¸õ   i  #ç        ?2¹¾Cv#?ìaÑ/	   b  $P        ?}|âÝ?ìhL?’õø   _  $²        ?¥¼¨úpˆ?ìgb5éÎ   ]  %        ?6¥]HÉJ?ì_”®©#L   _  %n        ?,‰ÙWu?ìd"Ýaˆ"   `  %Í        ?É°=œ6É?ìaÇlÍØŠ   a  &-        ?Î‹Ë&lx?ìXÞ¸<f£   _  &Ž        ?ú³Ý¸%?ìfÛŽ(Û   e  &í        ?îµÚ¤Òò?ìa~ÍóPE   _  'R        ?,‰ÙWÐ?ì\XÅa=F   `  '±        ?G¾šÉÁk?ì`/mü   `  (        ?˜¬€f?ì[8¬«Œ   ^  (q        ?¡½,ù¸?ìW7¬)B(   ]  (Ï        ?âVÌñ?ìU[3TW   a  ),        ?Î‹Ë&jX?ìLÊCÂ_q   c  )        ?+·}ÓÒK?ìTš5«N   ^  )ð        ?Mî¶ø?ìN*mÓé   ]  *N        ?Ô»°Ça?ìL šKì   a  *«        ?Î‹Ë&m.?ìDér;*4   a  +        ?Î‹Ë&kh?ìBI,ci8   a  +m        ?É°=œ5“?ì9Á C7#   ]  +Î        ?Ô»°Ç?ì2–¯®êø   `  ,+        ?˜¬€f?ì2â?"­   a  ,‹        ?‘òcT¿)?ìCp˜=…/   ^  ,ì        ?¡½,ø‚?ì5¶²cÀÚ   a  -J        ?Î‹Ë&jX?ì7A ¦9   a  -«        ?ýŠÒ>Â÷?ì.¶_ªá[   ^  .        ?Mî¶S?ì-‹*:E†   ]  .j        ?¹†î ?ì,÷tM7ƒ   _  .Ç        ?6¥]HÉJ?ì„Êdá   a  /&        ?%2øá?ì;&ÎyX   _  /‡        ?:$:n%?ìÜÏîGb   a  /æ        ?¿“±l²?ì9šÕBø   ]  0G        ?¡½,ø‚?ìo¨7H¤   a  0¤        ?UXûƒÐ?ì)¨õjÿŽ   d  1        ?UXûƒ?ì(£ŸÛDO   e  1i        ?îµÚ¤Ñ‡?ì.Þ$W   a  1Î        ?„X›l??ì&
+í0   c  2/        ?¿“±lW?ì$Å4¢}„   c  2’        ?ZNIŽÎó?ì'åü¿í   b  2õ        ?„X›nº?ì.@öq½ê   _  3W        ?¥¼¨úox?ì2”Êã«Š   a  3¶        ?„X›l??ì*l1'í   _  4        ?ïxÅz?ì¯?   `  4v        ?˜¬€g7?ì'BÓ1´B   b  4Ö        ?Àñjm?ìYüu<S   b  58        ?%2ø—?ìø]¼   ^  5š        ?˜¬€g7?ì&Æñ»î   e  5ø        ?ZNIŽÔŸ?ì7Õ¥Ý   ^  6]        ?Ôž+\?ìÀIµ    a  6»        ?É°=œ5“?ìJ!:„Œ   ^  7        ?i#A(Äþ?ìb•Ð   b  7z        ?É°=œ4]?ìIg©.´   b  7Ü        ?UXûƒ;?ì–Dz¸®   a  8>        ?³W	³Ä(?ì-ÃþAx   d  8Ÿ        ?}|âÝ?ìn5¡«   ^  9        ?Mî¶c?ìïM:Ú³   ^  9a        ?Ôž*&?ëúv„·   d  9¿        ?áyë~B?ìÿÿŽC   c  :#        ??ˆ'³?ëîþ]Ê¬   b  :†        ?%2ø<?ëí;Ûð¯   b  :è        ?UXûƒû?ëä>;>—   b  ;J        ?¿“±hq?ëÍ¿hëÿ—   a  ;¬        ?„X›n_?ë°Y½ß .   i  <        ?2¹¾Cq-?ë†oã€…‰   a  <v        ?%2øL?ëX¡ï‡a   `  <×        ?¸LW¿€1?ë4ÿÛ3`   b  =7        ?ú³Ý¸%?ëÒ…â÷   c  =™        ?áyë{l?ëŒî—Ð   c  =ü        ?L³èÕ€¤?ë%Mw   b  >_        ?ú³Ý¸%?ë5:èq8~   c  >Á        ?¹v;ßCº?ë^þÝ¦É   e  ?$        ?áyë€b?ë…§'X§   d  ?‰        ?ZNIŽÓ4?ë¦™Ïzó%   a  ?í        ?É°=œ5“?ë·®Ç€°Û   c  @N        ?¸LW¿€æ?ëÐ ÂŒ   d  @±        ?Åæ¸xÍË?ëß€ZVkf   _  A        ?6¥]HÈ?ëèÓ£%   g  At        ?
+üP;^&8?ëáDôÙ   a  AÛ        ?ýŠÒ>Ä¼?ëî4ÇRŽ   b  B<        ?¿“±ký?ëçç <   d  Bž        ?UXûƒ?ëìë’ƒ­
+   ^  C        ?˜"HA2?ëó9ïÝ´   _  C`        ?6¥]HÉJ?ëôÔTzå   h  C¿        ?A“<½½Ü?ëðˆx—   _  D'        ?Ô»°Åö?ëë¢_)•   c  D†        ?É°=œ5“?ëíš%»r]   c  Dé        ?É°=œ5“?ëáíÊÚ   `  EL        ?:$:nÛ?ëé™J
+úC   b  E¬        ?˜¬€g7?ëàñ†~&¼   d  F        ?L³èÕ}Î?ëâßä]Ü•   d  Fr        ?L³èÕ{®?ëç"­ª˜¥   e  FÖ        ?¹v;ßCº?ëà·Oƒ,,   e  G;        ?áyëx–?ëÛcpê’¡   d  G         ?¿“±lW?ëÉ8s
+|l   `  H        ?³W	³Ä(?ëÂÊÍ$Ê   b  Hd        ?ú³Ý¸%?ëÆŒ‹°*   `  HÆ        ?É°=œ5“?ë¿w›¥3   _  I&        ?˜¬€g7?ë»À-C%í   b  I…        ?Ó2)’?ë±Ç;'Á   c  Iç        ?Åæ¸xÐ ?ë»ë‡‘"F   g  JJ        ?	ß‹ü†¹?ëÀ e|„   a  J±        ?ú³Ý¸ï?ë¼ˆ±Àí   c  K        ?gèªH*º?ë·B{e9ð   d  Ku        ?¸LW¿~Æ?ë¦L]…Z   a  KÙ        ?„X›n_?ë yÎ£R   b  L:        ?¹v;ßF&?ë™/ˆ?Ê   _  Lœ        ?:$:o?ë\ÊÞíZ   _  Lû        ?˜¬€f?ë‡rÇÈ+    d  MZ        ?¹v;ßF&?ë„ŠìÏŒ   b  M¾        ?%2ø—?ë|QEjE®   c  N         ?UXûƒ°?ëŒö'¾
+U   b  Nƒ        ?ïðq…p?ë”XR#<   e  Nå        ?Åæ¸xÖL?ëœª‰=Ì©   c  OJ        ??ˆ+ô?ë°Ç³¶’   f  O­        ?Åæ¸xÖL?ë­ùÛ¡   c  P        ?+·}ÓÓ?ëµéÿní€   e  Pv        ?Ó2(Ü?ë½mÙ†þ°   `  PÛ        ?ÀñjmØ?ë½y6JvÒ   b  Q;        ?+·}ÓÒK?ë¬Ñh8$G   a  Q        ?¹v;ßF&?ë·n¢ºX   e  Qþ        ?žR--wÐ?ë´Ñ>®W   b  Rc        ?¹v;ßF&?ëªwÚÁx&   c  RÅ        ?Ó2&?ë¡îÞƒÁÒ   d  S(        ?
+üP;^$?ë„ IÃ5   _  SŒ        ?ú³Ý¸ï?ë…á¾Î`    ^  Së        ?˜¬€g7?ëqò@2T   d  TI        ?áyëx–?ë_¿³Hš…   d  T­        ?
+	êœ{?ëW!‚\ø   c  U        ?
+üP;^!A?ëIå¢Ïá   ^  Ut        ?¿“±kG?ë0Î§   c  UÒ        ?
+üP;^!÷?ët©¥(   _  V5        ?+·}ÓÔ·?êþzó”ž   _  V”        ??ˆ'³?êÐó5cÉÂ   ^  Vó        ?ÀñjmÈ?ê¥LTrë‰   [  WQ        ?ïðq…p?êb¯S+›Ž   a  W¬        ?}„¼N„m?éèåBšàÀ   ^  X        ?+·}ÓÔ·?éAF‚3d¦   _  Xk        ?¹v;ßF&?è&€¤xR   _  XÊ        ?uƒxT?ç¬¹¥,w   c  Y)        ?žR--ve?æÛ~ìR%Ý   _  YŒ        ?%]Š2?æ9*þx?   \  Yë        ?	ß‹ü†¹?åç6É®ªR   [  ZG        ?£š|õ_l?åõ6:êÍI   \  Z¢        ?Mî¶?æûŒÍL—   ]  Zþ        ?¹v;ßCº?æG:[)Ã|   a  [[        ?}„¼N‚?æ·¸¾Ü   d  [¼        ?	ß‹ü†!%?çWèT}#·   f  \         ?žR--tE?èþµë   j  \†        ?Ô»°Ç?è´{ÇÅ…   e  \ð        ?îµÚ¤ÐÒ?éK‡ÆãÈê   f  ]U        ?A“<½»q?éÖY…ÃY™   h  ]»        ?[ˆàoo>?ê/\¦îUN   b  ^#        ?L³èÕ}?ê^©#F¬›   f  ^…        ?A“<½½Ü?êzÖ47BÜ   c  ^ë        ?
+üP;^'¢?ê1OJ   \  _N        ?g¨ýd–p?êˆï„ÿ[÷   ^  _ª        ?ú³Ý¸%?ê’ÝyÍ   e  `        ?«ìæÎ¡?ê›$€.Á   d  `m        ?	ß‹ü†#?ê°&U*   ]  `Ñ        ?³W	³Å8?êÃi°‚§`   `  a.        ?!®Êé?êße¾)9   b  aŽ        ?7z?%¤?êù™Aö,~   b  að        ?‰d¦íNa?êýý`=   e  bR        ?
+(ìkap`?êú3Î¼{ã   c  b·        ?æa ½?êôÑulI   a  c        ?JU÷?êãå‘>   d  c{        ?	ÌR‚à|w?êÎ´íGLÖ   `  cß        ?Ø5Ù–?ê¸NÅT   f  d?        ?ùù|ð^?ê²Î©|Ö   `  d¥        ?SL6ÒM?ê®¤HyBR   ^  e        ?–W#à-È?ê´¡;‡Ç   d  ec        ?	e!8ÔÿK?êÃê¬6©   b  eÇ        ?Ô?gS’?êÚ5#ç~   c  f)        ?
+3ƒÌëÿN?êñyHy®I   `  fŒ        ?³‘ÌNñ?êüíëÀ   d  fì        ?Èt/Õ”Ë?ë^©âõë   _  gP        ?!®ÊéV?ë^(ýá`   _  g¯        ?³‘ÌOL?ëºªÖeE   b  h        ?‰d¦íNa?ë/ñFOa   _  hp        ?…¢ÊŽaü?ëÒ€   ^  hÏ        ?ˆàô”£?ë
+[ÏPË×   ^  i-        ?ò˜Þ•?ë,‹‘ø±   e  i‹        ?È\¦øã?ëhyûuo   `  ið        ?…¢ÊŽaü?êù¯¡¦'Š   a  jP        ?	ÓEv2?êÿÛ÷|*,   `  j±        ?…¢ÊŽ`Æ?êüDƒËÏ   `  k        ?SL6Ò¸?êù T3c   b  kq        ?mH_?êòŽœð®~   b  kÓ        ?JU÷?êë‡Íð¨   d  l5        ?ýïîÉu]?êê[J6N¹   a  l™        ?éÜây)ö?êßœ¼¾}p   d  lú        ?i«‡?êáÀÆ1ïd   `  m^        ?!®Êé6?êÛRvî   _  m¾        ?î%ãTE?êÖj{ïm   e  n        ?Èt/Õ”Ë?ê×zöžÎ»   a  n‚        ?³‘ÌO§?êÒ;Ü4Ÿ   c  nã        ?‰d¦íKõ?êÕ'ørh   d  oF        ?	e!8Ôþ–?êÚÇ¶ñ   b  oª        ?¢¡ûj˜0?êËéU Ö   ]  p        ?¾só„?êÔ}EfP   g  pi        ?ö
+Vc”?êÐ3¡1±   ]  pÐ        ?Ào,3án?êÊÆÌµ_ˆ   c  q-        ?‰d¦íNa?êÐÏ°>_°   _  q        ?º}€Ý’$?êÅø½   `  qï        ?Ø5Ù+?êÈˆÊ‰˜   `  rO        ?†äÛ×ÏN?ê».‰Ô¾½   a  r¯        ?…¢ÊŽaü?ê¹©ÊÕ?Ï   b  s        ?Ô?gS–Â?êºO4…4   c  sr        ?mH?êµgû›Öª   ^  sÕ        ?F“A¦’?ê®7ãfC9   e  t3        ?Èt/Õ’`?êµgVÝs   a  t˜        ?ªÍYåø?ê¨ÆˆßÚ   e  tù        ?
+šµ÷†g?ê¢›ºWã   b  u^        ?Ø5ÙU?ê§±Ó#²   [  uÀ        ?ÊWIÃ»½?ê—IÇK(   ^  v        ?ÂjeP¦i?ê•3ÝÜV   a  vy        ?†äÛ×Ñ?ê’a„ÖÎ   b  vÚ        ?mH?êˆXýÿ M   ]  w<        ?)›¯\(‹?ê<œ€ÌG   c  w™        ?
+(ìkap`?êm/4I¢¡   c  wü        ?
+3ƒÌëþ™?ê`#‰e ‡   c  x_        ?i«†j?êIH2Šmç   c  xÂ        ?æa ½?êL•°„   a  y%        ?7z?%Œ?êCƒAªÏ   ^  y†        ?…¢ÊŽaü?ê<2þ£—   ^  yä        ?æ?ý?ê6ó4@   a  zB        ?ÜÓ<“3?ê,©‡AA   ]  z£        ?F“A¦þ?ê&¯¨ ®‘   b  {         ?éÜây,b?ê›½î“   g  {b        ?§}1úÉ?êFš%Ü   `  {É        ?;p±_.?é÷ÆXRa   ^  |)        ?î%ãPº?éòë2RHÛ   \  |‡        ?–W#à.þ?éÛcøÈ=_   g  |ã        ?§}1úÉ?éµ`<3   _  }J        ?ž«‰1?éŒ÷‹þº   d  }©        ?ùù|éý?éHæ…G   f  ~        ?Äežmh?èÄµÑAfS   \  ~s        ?†äÛ×Ó4?è+É&&ž<   ^  ~Ï        ?mH‰?ç¸Ê@Úõé   ]  -        ?ýïîÉ{¾?çeÝ"‰æ   `  Š        ?¼x¹úUY?çQŸiä¾   c  ê        ?ö
+VgÔ?ça¯~   ^  €M        ?ÜÓ<¨?çmOsre   k  €«        >ÿq™ž?ç¬—óm   e          ?–¾¤½ür?èæ©»O   e  {        ?Èt/Õ’`?èf{Äˆz   a  à        ?JU÷?è¸Q®ÛÃ   c  ‚A        ?
+(ìkap`?èóé­a   `  ‚¤        ?
+3ƒÌì¯?éæ
+]â   _  ƒ        ?i«t?é.œnvcŽ   b  ƒc        ?–¾¤½úQ?é7W1áó   b  ƒÅ        ?ýïîÉyž?é>^]   c  „'        ?a*Æ›oª?é=äÕ)   a  „Š        ?‰d¦íPÍ?éN¾e”€   b  „ë        ?‰d¦íKõ?égdg/rÏ   e  …M        ?Äežmh?éu:yR%   _  …²        ?	ÓEvœ?é…”8œ   c  †        ?gûôI¶Ë?é‘¯Ô”¦—   e  †t        ?a*Æ›p`?é•s=ðÅ   ^  †Ù        ?SL6Ò§?é™žÓ7k   ^  ‡7        ?mH5?é••Tù3   c  ‡•        ?	ÌR‚à|w?é’FÉ:_   c  ‡ø        ?	e!8ÔÿK?éŒ´r   _  ˆ[        ?Ô?gS–?é€`dyù›   d  ˆº        ?–¾¤½úQ?éx§œG‹½   `  ‰        ?i«‰õ?étl¾e   \  ‰~        ?WB©šR?éjþYÖv   ]  ‰Ú        ?î%ãRÛ?éi\¾^u   a  Š7        ?i«‰@?ébo5Ò3   d  Š˜        ?a*Æ›x,?éeµ¯s   ]  Šü        ?qœt?éd†nåí   `  ‹Y        ?
+(ìkamõ?éZâ!-   c  ‹¹        ?a*Æ›ww?éNTdèÖ×   b  Œ        ?ùù|ôŸ?éM5cÒåø   _  Œ~        ?7z?%‡#?é>òô7‡¥   b  ŒÝ        ?Èt/Õ’`?é3·Æ´š¾   _  ?        ?ÜÓ<‡?é*-PGè×   \  ž        ?5ÞèTOÇ?éË@<íQ   \  ú        ?¢¡ûj•Z?é§‘L–   [  ŽV        ?ŠÛN[?èòÿ	`   ^  Ž±        ?JU‹?èãc_âpF   \          ?ªÍYèd?èà‘éÈ’P   _  k        ?Èt/Õ’`?èÕ;‹¾<   a  Ê        ?ƒ¸½ØÊ?èÐ·:Û   [  +        ?5ÞèTPý?èÐÍ¾“G   ^  †        ?qž”?èÕŽ)mu   ]  ä        ?ž«‰1¦?èÌ­{|÷#   Z  ‘A        ?æ>Ç?èÓ5Û&Æ²   \  ‘›        ?5ÞèTR3?èÉÏ&02Ä   \  ‘÷        ?î%ãS5?èÆð™âø¾   a  ’S        ?gûôI¶Ë?èÉEw8ïj   c  ’´        ?ŽÑÀJâÜ?èÀS™<)R   _  “        ?
+(ìkamõ?èµ_-|J'   ^  “v        ?éÜây,b?è­'_Øâ}   \  “Ô        ?JU÷?è¤êT‡ã   ]  ”0        ?ÐHõ
+¬?è—pu>`   `  ”        ?	ÌR‚àzV?è‡Ô…
+JÓ   ^  ”í        ?	ÌR‚à‚Ø?èƒefÛÔT   ]  •K        ?‰d¦íNa?èz¿®4í±   ]  •¨        ?
+(ìkamõ?èn?ê¸YD   ^  –        ?‰d¦íNa?è`”³7Í   \  –c        ?;p±_­?è\UflaZ   b  –¿        ?' v?ap?èSÔ®º€œ   \  —!        ?‰d¦íKõ?èD‰0H]   a  —}        ?’È2„kf?èA:Çg¥   Z  —Þ        ?5ÞèTOÇ?è1šºÙ…¦   \  ˜8        ?ýïîÉx3?è*­^šù'   b  ˜”        ?F“A¦È?è|Uäµ   ]  ˜ö        ?i«ˆŠ?çûlï_   \  ™S        ?ýïîÉw}?çëÎE¦   _  ™¯        ?Äežmkc?çØU¼ýS   [  š        ?¢¡ûj–Å?çË¢ ’Œ   ^  ši        ?Èt/Õ”Ë?çÇ·œ6:   X  šÇ        ?JU
+c?çÂ®äœT6   Y  ›        ?ž«‰1?çÃñÈÇîa   ^  ›x        ?
+(ìkap`?çÊÀ%:ˆ   _  ›Ö        ?/Z²xå?çÇ¡PÂ   ^  œ5        ?	e!8Ôýà?ç¾Š[ÿE   ^  œ“        ?’È2„nò?ç·âô^ƒ   [  œñ        ?
+(ìkap`?ç¶¸Ðî   Z  L        ?JU‹?ç±+ëfõ‚   [  ¦        ?;p±_™?ç¡E"ìê   Y  ž        ?ªÍYåø?ç–‰Õ§L   \  žZ        ?
+(ìkarÌ?ç‡·GF   V  ž¶        ?F“A¦È?ç|4Ú4K   [  Ÿ        ?ž«‰1?çf	%íÅr   Y  Ÿg        ?q˜é?çZË8›½   Y  ŸÀ        ?ªÍYåø?çJV×‡™£   [           ?
+(ìkap`?ç:ßÊ¢ž   a   t        ?Ào,3Ýã?ç.Ä{é€V   _   Õ        ?Y=â(`·?ç".ñ)îÂ   a  ¡4        ? î%ãV?çb}µ   [  ¡•        ?gûôI¹6?ç7f%…   [  ¡ð        ?gûôI´_?æÞl²5   ]  ¢K        ?ƒ¸½ØÊ?æ¸p¡   \  ¢¨        ?–¾¤½ùœ?æßZòS   \  £        ?	ÌR‚à}â?æbÐI¼   Z  £`        ?ž«‰1Ð?æRx7)&   [  £º        ?Èt/Õ’`?æ>Ig¾«t   ]  ¤        ?Ào,3à¹?æA!B]³‚   \  ¤r        ?ö
+Vjª?æNâ´\€}   ^  ¤Î        ?Ào,3âÙ?æ[úÙ}Ìp   [  ¥,        ?ƒ¸½ØÊ?ækUÅšõ   [  ¥‡        ?–¾¤½ø1?æj	°t*   ^  ¥â        ?§}1úÉ?æcô5­Y   Y  ¦@        ?JU÷?æZƒƒ^}   X  ¦™        ?;p±_O?æGö±ù8   [  ¦ñ        ?gûôI¶Ë?æ;\h@$   ]  §L        ?#ªÙ›?æ/–Åƒ—²   X  §©        ?7z?%‹d?æ.ƒI»L   Y  ¨        ?
+(ìkap`?æ‡zš6Ñ   [  ¨Z        ?
+(ìkarÌ?æ¬ïy´   ]  ¨µ        ?Äežmnî?åý‰)-N1   Y  ©        ?
+(ìkap`?åï`|éëâ   Z  ©k        ?/Z²t¤?åå6Û   W  ©Å        ?	ÓEv2?å×EîŒÍŸ   X  ª        ?JU‹?åÆ_€<Œ$   X  ªt        ?æa	>?å»‡bqp   \  ªÌ        ?’È2„n<?åµ¢15„Ô   ]  «(        ?ƒ¸½Ö^?å§zö„zË   [  «…        ?	e!8Ôýà?å¤ª&¾f   [  «à        ?Äežmn9?åƒm’%î   W  ¬;        ?JU÷?åz¥«qN   \  ¬’        ?+–èxê¯?ågÞ<Ÿ7   X  ¬î        ?;p±_Ã?åW…õ¶XY   Z  ­F        ?ýïîÉyž?å>{žJÝ   \  ­         ?gûôI´_?å+þ×'ë7   X  ­ü        ?	ÓEvœ?åpÓK   [  ®T        ?æa³?åC¯Ë3û   \  ®¯        ?ýïîÉyž?åÏ¢Ãò#   ]  ¯        ?a*Æ›r€?äé¾ýòÿ   W  ¯h        ?ñÈùJ¨?ä×FÅÍO   [  ¯¿        ?a*Æ›qË?äÉÅ¨×÷   W  °        ?JU÷?äªf¢C·   Y  °q        ?±wµ<Ñ?ä ÌÄÜvY   ^  °Ê        ?ƒ¸½Û6?ä™FÊÞ†Ú   ^  ±(        ?/Z²{?äl¨/™C   Z  ±†        ?ƒ¸½Û6?äX·ïÙ&   \  ±à        ?Äežmkc?äIÚ'6Dƒ   ]  ²<        ?gûôI±ó?ä!be=Q—   \  ²™        ?/Z²yš?äØ$šË=   Z  ²õ        ?ùù|ñÉ?ãÐâ)¾   T  ³O        ?…¢ÊŽ`Æ?ã—ûfÉ   [  ³£        ?ùù|ì?ãM¼šŒ   W  ³þ        ?ªÍYåø?ã[|ÆÌ   [  ´U        ?
+(ìkap`?âÆwa‚ã   ]  ´°        ?ƒ¸½Ö^?âœá^û;   Z  µ        ?JU÷?âƒ÷ß…›J   _  µg        ?F“A¦È?â‚Îz]´   \  µÆ        ?ŽÑÀJç?â wdnÝï   c  ¶"        ?UGoî×x?âÇÆFçh¶   ]  ¶…        ?gûôI¶Ë?âè±;IÌü   a  ¶â        ?Ào,3äD?ã
+¨-³   [  ·C        ?Èt/Õ’`?ãï¶2	   _  ·ž        ?§}1ý5?ãÞÓ"3   \  ·ý        ?Èt/Õ’`?ã½™&¬   [  ¸Y        ?ƒ¸½Ö^?ãž.…§   _  ¸´        ?ŠÛN[?âûÙvuË   ]  ¹        ?
+(ìkamõ?âîî\›Ý   ]  ¹p        ?ùù|ò?âß„öYh   c  ¹Í        ? †äÛ×Óé?âÒ_ëê   \  º0        ?
+šµ÷‚&?â´\éQ«¥   [  ºŒ        ?éÜây,b?â›ôŽ35   ]  ºç        ?‰d¦íKõ?âŽRzå¯   a  »D        ?Ào,3Þ˜?ârÔ°‘­   `  »¥        ?Èt/Õô?â[{îÁ   [  ¼        ?‰d¦íIŠ?âGüˆL   ]  ¼`        ?ƒ¸½ØÊ?â&ÑíÑ   _  ¼½        ?gûôI¹6?âßr|	   ]  ½        ?Èt/Õô?áþî~ï<   _  ½y        ?’È2„nò?áèÜÍôŠv   _  ½Ø        ?]4Taì?áÕç‡ÒÑ   _  ¾7        ?gûôI¶Ë?á´c”   ^  ¾–        ?–¾¤½ø1?á™#AwÕù   `  ¾ô        ?gûôI´_?ázøz€Ëe   ]  ¿T        ?Èt/Õ’`?ác¦†:Õ   c  ¿±        ?³rQdŸ?á>MÌdS   ]  À        ?bdú²„?áùó	¼   [  Àq        ?›•pº:n?á’un    a  ÀÌ        ?	Œåè€÷o?àîb	Æ÷   ^  Á-        ?›•pº99?àËÙ›	Öo   `  Á‹        ?bdú·\?à£&(ÍF   ^  Áë        ?©ãÍðá?à~ÿÏ„%   `  ÂI        ?	Î­f;‹?àa°ãËäÌ   _  Â©        ?bdú·\?à?…ÄVä   _  Ã        ?Eºä?à<9íœ   Z  Ãg        ?[I+pÙ?ßÏbÜPê   c  ÃÁ        ?ðb¡8ì?ßˆRü ¬ó   ]  Ä$        ?p·í3÷ð?ßL™£7“¨   [  Ä        ?·Ãl9S?Þí;‡	’   a  ÄÜ        ?«i¸ñ?Þªt4l,   Z  Å=        ?þÎêÚw¯?ÞV­~Y»g   \  Å—        ?2q9.ŸÒ?Ýþ©†íú   d  Åó        ?+zÅ?Ýªí»^Û†   `  ÆW        ?©ãÍõ¸?ÝSèƒû   d  Æ·        ?
+ÓñgT87?Ü°#d>O   f  Ç        ?¯mðŽPé?Ü ÊÌòr   h  Ç        ?Ò±;úÍ?ÛsBÊ°ŽÍ   d  Çé        ?EÚi­¹?Úµ\Ä(W”   g  ÈM        ?·Ãl7‚?Ùå]Äšð   e  È´        ?þÎêÚy€?Ùc»(t   g  É        ?±p ù0/?ØÂa«Å   i  É€        ?2V²ˆ?ÖÈÅž›&p   k  Éé        ? tóõ´4à?Ôøˆ@A:Á   g  ÊT        ?Ò±;úÍ?Ó3}]¶!   g  Ê»        ?)¬n`ºÉ?Ñ—AIRËw   g  Ë"        ?)¬n`¹“?ÐÎ²û²   k  Ë‰        >þ©ãÍõ¸?ÍUåwÅßJ   j  Ëô        ? ›•pº:n?Ê÷¢8{dÀ   e  Ì^        ?)¬n`¸ø?É%¶º   f  ÌÃ        ? Ô³¯¦Ún?Ç¼þ­íDs   b  Í)        ?·Ãl9S?Æ²à/˜LÚ   d  Í‹        ?â ïzœ?Æ(ûÆÏZ   g  Íï        >ülë4¹ç?ÅÖîõŠtU   b  ÎV        ? Ô³¯¦Ù0?Å‰)*píF   f  Î¸        >÷0oÃ¿N?ÅC©ÑI­   _  Ï        ? tóõ´6?Åý­§   ^  Ï}        >ÿjéÜ?Å4`xã,   ]  ÏÛ        ?â ïz?ÅCÔÑÕï   Y  Ð8        ?	Œåè€÷o?Åˆ~Â²°ˆ   c  Ð‘        >ÿjéÚü?Å®É«e9   d  Ðô        ? 4;Á‘Î?Æ!1×{þ   c  ÑX        ?”3#Œ!ý?Æü‰Þ»}r   d  Ñ»        ?”3#Œ!ý?È}½eÙ   g  Ò        >þ©ãÍöî?Êˆ?þ9Ó—   f  Ò†        >þ©ãÍô‚?ÍIpÇ±Rv   c  Òì        ? ›•pº:n?ÐW¨I:=   _  ÓO        ?rñÅIX?Òú¦¾ªE   `  Ó®        ?â ï{7?ÓÁ@•ƒ×   _  Ô        ?Ò±;üí?Õhr `PÎ   [  Ôm        ?­kÀ#rX?ÖðÍ¿QaV   ^  ÔÈ        ?/ÚëÓœ?ØLÝ«@þ   d  Õ&        >ýëêÓK‚?Ù‚`V8ã    c  ÕŠ        ? ›•pº;¤?Ú|¡í°ƒn   b  Õí        ?þÎêÚxJ?Û>Æˆ¡ø¥   ^  ÖO        ?
+ÓñgT87?ÛÔ|ÀM‘   b  Ö­        ?þÎêÚy€?ÜO kO…£   `  ×        ?	níds˜Ó?Ü«vŠŒó   f  ×o        ?”3#Œ$?ÝHì;    _  ×Õ        ?üæ't(?ÝX[+á>   _  Ø4        ?üæ'u^?Ý ÍBº   Y  Ø“        ?p·í3÷ð?ÝÊÊš^À   Z  Øì        ?)¬n`º.?Þ!›‹¹   ^  ÙF        ?
+ÓñgT3`?Þc@×‚'‘   \  Ù¤        ?dSF’Ðt?Þ™öF|ò§   [  Ú         ?›•pº<Ú?ÞÐ®H)Žè   ^  Ú[        ?Ìªíû\D?ß¨H’ÿy   X  Ú¹        ?2q9.ŸJ?ßAÐ™®×$   Z  Û        ?ãR.]aY?ßŠ›¼lð   `  Ûk        ?
+Ž,’K‡[?ßÊcëÂÛ2   `  ÛË        ?
+.lØXã“?ßûfçÕ?   X  Ü+        ?[I+pÖ°?àÑ.¬4   [  Üƒ        ?â ï{7?à:ø«cà   ]  ÜÞ        ?›•pº;¤?àXa G   `  Ý;        ?
+Ž,’K…ð?àn‰DfY   ]  Ý›        ?”3#Œ"X?à•N>²f   `  Ýø        ?tóõ´7[?à©h¿SeË   \  ÞX        ?S²—qi2?à¾Ée¯w†   Z  Þ´        ?#Òºxo?àåÎ´#ñ   \  ß        ?4;Á”I?àöÝÀ¨r   [  ßj        ?tóõ´4+?áo¤ºoR   \  ßÅ        ?«i¸ñ?á.°GÐºÔ   _  à!        ?Ô³¯¦Ù^?áIwN9nâ   Y  à€        ?þÎêÚz¶?áY±Ïch¦   Y  àÙ        ?)¬n`½5?áyP+æVˆ   [  á2        ?Í2-Ê\c?á‘è+Þ?   W  á        ?pï”Þz:?á³µü~>Š   Z  áä        ?`Nå½B?áÃfôTH   `  â>        ?jéÜÂ?áá¥&âõ	   a  âž        ?	Œåè€ò—?áÿsâêôâ   e  âÿ        ?	níds™.?âL|5   ]  ãd        ?¤ÓÒ­„ÿ?â5×"I‰»   [  ãÁ        ?Ô³¯¦Ù?âFt{!²r   \  ä        ?ðb¡/=?âhYVÌ~F   ]  äx        ?
+ÓñgT:£?â}`áÙ   ]  äÕ        ?©ãÍõ¸?â‘TSŒÒ6   ]  å2        ?›•pº99?â¨Hê´¹   \  å        ?)I«:e?âºÇåb·   ]  åë        ?O®6›©–?âÍ?ƒŠ»   [  æH        ?
+ÓñgT:£?âìˆD6õí   ^  æ£        ?	nídsš™?âö•@E±å   Y  ç        ?Eºä?ãÌ±­   \  çZ        ?Œ*aà¥š?ã“–ðB’   ]  ç¶        ?Ð¯NÑ ?ã5bSyì   X  è        ?©ãÍõ¸?ãO
+~ž\–   [  èk        ?þÎêÚuÞ?ã_ÿ˜[   Z  èÆ        ?©ãÍú?ãp“l_ˆí   c  é         >ý,j§íú»?ã… E   a  éƒ        ?)¬n`ºÉ?ã˜u[>Ú   [  éä        ?M¬0Êª?ã¦§tÝ   [  ê?        ?Ãõ’/ù?ãÁTtìª   [  êš        ?EÚi­¹?ãÕ3QÐýô   ^  êõ        ?Ò±;ý£?ãàRYCvá   ]  ëS        ?’0ó!CÇ?ãíŸkˆ9©   [  ë°        ?üæ'xÿ?ãþB¿I<W   ^  ì        ?·Ãl7‚?äß)á   [  ìi        ?
+ÓñgT0ô?ä‰½¹‡f   _  ìÄ        ?pï”Þv®?ä8‹ ·ä   [  í#        ?
+íìL>)¸?äBn}{ä3   [  í~        ?­kÀ#m?äR h   ]  íÙ        ?	Œåè€÷o?äd©p·~   \  î6        ?bdú·\?ärKŸd†À   \  î’        ?Ìªíû\Ÿ?ä‰ArªÙP   Y  îî        ?Ê¨½?äŽA/àp   [  ïG        ?	Œåè€üG?ä¦"}ÚÝâ   Z  ï¢        ?
+ÓñgT:£?ä¹£	Víœ   ]  ïü        ?.Â¶g²?äÈþez~   _  ðY        ?’0ó!@ñ?äæ"ÀÄŽ   a  ð¸        ?/ÚëÐ?äïæ‹‘äµ   a  ñ        ?rñÅIT/?åU¤±„¢   ]  ñz        ?
+ÓñgT5Ë?åˆÖ@›   Z  ñ×        ?
+ÓñgT:£?å#°ß£f”   \  ò1        ?¯mðŽWJ?å4J´r   ^  ò        ?·Ãl<Z?å@§˜BÄ«   [  òë        ?­kÀ#r³?åSÍûzP®   `  óF        ?0oÃ¿©?åZ}~– ±   Y  ó¦        ?­kÀ#t?ånûÜt   Z  óÿ        ?	Œåè€÷o?å{¸O¾p   ]  ôY        ?ñð­êe?å‹ÁlŠô¦   `  ô¶        ?”3#Œ"³?åš}Ã‹õ   `  õ        ?p·í3ù&?å£ ñ:Oï   ]  õv        ?EÚi­½ê?å»	y|;v   ]  õÓ        ?þÎêÚuÞ?åÆï‰Bÿ   [  ö0        ?lë4ÁY?åÌ·ÑÆè   \  ö‹        ?	Œåè€÷o?åá…³ÈÑæ   \  öç        ?
+ÓñgT5Ë?åÚt¼3Pr   ^  ÷C        ?	nídsžÙ?åîÌðE   ^  ÷¡        ?
+Ž,’Kƒ?åøÂ@Ëi   a  ÷ÿ        ?³rQdà?æÕ}l   \  ø`        ?EÚi­´;?æ
+M–½N   _  ø¼        ?Q°gˆ?æ;ZG-]   _  ù        ?pï”Þx?æ’å„L    [  ùz        ?O®6›­Ö?æ%€]îh   a  ùÕ        ? ›•pº99?æ@2Ë³¿Â   _  ú6        ?/Úë×'?æEðñS2õ   ^  ú•        ?.Â¶j‡?æ`Îh«}ë   [  úó        ?bdú·\?æs™æîˆ   c  ûN        ?â ïr½?æ…Ãi©¿]   ]  û±        ?	Î­f7J?æ2DºÊ   ]  ü        ?	Œåè€÷o?æŸ¡º   \  ük        ?bdú¼3?æ«!yçp1   [  üÇ        ?üæ't(?æ¿‡ùx¦ð   ^  ý"        ?üæ'xÿ?æÀÙ=St´   Z  ý€        ?©ãÍú?æÕ›¸ _#   \  ýÚ        ?üæ'xÿ?æà-âÈ   \  þ6        ?üæ't(?æãŠ‰}   \  þ’        ?ðb¡=Ä?æôÎfYà   ]  þî        ?	-ª€óû?ç2¶ï 4   ^  ÿK        ?
+Ž,’KˆÆ?çM}e   ]  ÿ©        ?üæ'xÿ?ç{wà´ù   Y          ?ðb¡4?ç*{ÃÚMw   _  _        ?þÎêÚz¶?ç3ü)Y“ò   `  ¾        ?·Ãl7‚?ç4   `         ?O®6›¬k?ç>n/†   d ~        ?p·í3ýý?çNøü0Å¥   \ â        ?Œ*aà©Ú?çTÁ'1	ž   Z >        ??0#ÚÓ?çi)gØ«‰   _ ˜        ?þÎêÚuÞ?çoýFa   ^ ÷        ?	Œåè€üG?ç{†­ËÜ   ] U        ?©ãÍú?ç‚ÈÅÅ   ` ²        ?ïî|©ø?çˆTuww   _         ?	Œåè€÷o?çI'ä°2   \ q        ?4;Á’)?ç¢©[1a   ^ Í        ?Ìªíû_u?ç¦¤/Gû8   _ +        ?þÎêÚz¶?ç·}X¨¥`   _ Š        ?EÚi­¹?ç¿˜	•0*   ^ é        ?¯mðŽUß?çÑ¥ÐÑ   ` G        ?ïî|©¤?çÞZI…|‚   ` §        ?EÚi­´;?çßÔÏ©†!   _         ?
+.lØXã“?çë)°&4è   ^ f        ?üæ't(?ç÷ÃË…>   ] Ä        ?
+ÓñgT:£?èD0„Í·   Z !        ?›•pº99?è1¢ò\   ] {        ?©ãÍõ¸?è	¦kõÉ   ] Ø        ?jéÛW?è«Ï•ýC   [ 	5        ?†&®÷?èÞnã—   \ 	        ?Eºæâ?è17)å©_   [ 	ì        ?›•pº;¤?è+ñˆ‰>   [ 
+G        ?dSF’Ñ„?è<éþäâ   ^ 
+¢        ?
+ÓñgT5Ë?èG°Š4o   ]          ?)I«4¹?èT;[Ì1   a ]        ?	nídsžÙ?è]ê¨1U¼   Y ¾        ?CèP à?è_®xæ¼   d         ?2q9.–?èu¶®È30   ] {        ?Eºáì?è|v¦ØS   ] Ø        ?Œ*aà¡Y?èyëÛ´#¨   \ 5        ?©ãÍõ¸?è|%Ò;Éê   ^ ‘        ?
+ÓñgT:£?è‡Ó7O.   d ï        ?2q9.šT?è–ˆ¦Å$   [ S        ?â ïw•?è’•Œ$£   Y ®        ?Í2-ÊWŒ?è‘wb,ß   [         ?)¬n`¸]?èœ]|"'Ç   _ b        ?Ê¨½ƒ_?è¨ ˆfå   ] Á        ?ëêÓC¶?è¸ß™¥y¾   b         ?	-ª€öÑ?èÀÞ;Ì#Î   a €        ?	nídsš™?èÃ@¢ŽE   ` á        ?
+ÓñgT5Ë?èÁ¬7ÕÙT   a A        ?O®6›¬k?èÑ6ÂÖ¡Þ   b ¢        ?O®6›« ?èÛx`Uª   ^         ?bdú²„?èç.UY|   ` b        ?	Œåè€ò—?èèjàx4}   _ Â        ?bdú²„?èè˜R   c !        ?0oÃ¿©?èñ¹pJ   e „        ?’0ó!Is?èüôåÕ×0   _ é        ?K©ÕÅèé?èò5œ²²Å   ^ H        ?ëêÓPx?éœÂ;ó,   ` ¦        ?+z»?éÄ™W@c   \         ?)¬n`¸]?éïW<   _ b        ?Œ*aà¥š?éø”$ó:   a Á        ?M¬0Ö?é!Ê«âË¼   b "        ?	níds™.?é#ÑÏfóÎ   \ „        ?â ïz?é(î¤üåA   a à        ?ÌªíûYÉ?é4o(?X   ` A        ?©ãÍðá?é6ÚÐÖ‘   _ ¡        ?Œ*aà§?éFèA».á   [          ?Í2-Ê\c?éPeîš   ^ [        ?Ô³¯¦Ù¸?éRƒw=_€   ` ¹        ?ðb¡4?éRé"¸IÈ   ]         ??0#ÚÓ?éRˆN¤ë   _ v        ??0#ÚÓ?é\Åƒs:4   b Õ        ?
+ÓñgT0ô?éc0kS   ` 7        ?
+.lØXæi?éhd·   _ —        ?«i¸–?éfèÆQZ   _ ö        ??0#ÚÓ?édQXIä   a U        ?«i¸ñ?éoN[‚Ó   ` ¶        ?,j§î¨?éw]ºG¡   a         ?
+íìL>&â?ét}¨aÉ   ` w        ?K©ÕÅòÕ?ér÷.D8   _ ×        ?«i¸“Ç?éqs²š¿˜   e 6        ?.Â¶fG?ée<åŠe+   ^ ›        ?Ä …s,?éV9y†Q¹   f ù        ?þÎêÚz¶?é;‰<cÌ6   ] _        ?O~VâÚ?é#&J:ž£   g ¼        ?
+¾ŒüÀ?é¦ÉÂ)   c #        ?Tw„`…?é
+”Áý*À   d †        ?ä©ÆÅ N?é7ì(ã   d ê        ?	ö¤½‚S8?éÒ„ä   a  N        ?‰œ
+²ç?éCÉ‰tß   `  ¯        ?â‹ow¤?éh‡ÓV³   _ !        ?Vjq°$?é‰ˆ95˜‰   d !n        ?	ö¤½‚QÍ?é’Ø´Iäã   d !Ò        ?É¦em?é¦sv	€   b "6        ?›yÊ…Ð?é·¼}¨   c "˜        ?>ÿžR‡?éÃ%t&$ë   c "û        ?>ÿžW_?é¼%$fAÊ   a #^        ?â‹ow›‚?éº;¢ òj   ` #¿        ?Sƒ¡?éÍdr¶å¡   a $        ?>ÿžW_?éÌÅáÎÎ   ^ $€        ?4¸§âÀ?éÃW=yºø   f $Þ        ?¯šÇÕ2.?éÏEt‡û²   f %D        ?:ÿ0L)?éÕ½ð­   b %ª        ?>ÿžR‡?éÜAÍí   c &        ?&åâA{<?éåU¥úà   a &o        ?Vjq°$?éçùÂTùÌ   b &Ð        ?&åâA~?éùÔþ§r   ^ '2        ?«U9p?éû½N    b '        ?=®³/d©?ês(ä¦   c 'ò        ?ùT@e”ˆ?éÿ
+²<Au   c (U        ?&åâAu?êWÍ$   a (¸        ?S†w?êŸòÁ   c )        ?&åâA|§?ê–:Õ   c )|        ?>ÿžR‡?êé”Ôá]   c )ß        ?‰œ
+©8?êÊÿt‰   c *B        ?‰œ
+·¾?êt[6á   d *¥        ?>ÿžW_?ê ÉžÌâÔ   a +	        ?Vjq²?êxH   e +j        ?É¦fØ?ê-ïÔéDž   e +Ï        ?&åâA|§?ê4"Êk•(   b ,4        ?eáODÔ?êB§©éÁ   b ,–        ?Vjq²?êMò2ð±   a ,ø        ?‰fJgo?êJÏ«û6   b -Y        ?›yÊ€$?êG]ÓQ3ì   b -»        ?„¸¨Ü ?êSÎ¬ì‡   c .        ?Ô8wo?êWÜ'ä   _ .€        ?4¸§Ýè?ê]ç_¹   d .ß        ?É¦hC?êbØ½ø   a /C        ?Ê²’Wå?ê^H§‰I   ` /¤        ?Ê²’\Û?êS„ ª   c 0        ?mï×î’Y?êLÆŠøª†   h 0g        ?QÈ:5?êaa9Fk   c 0Ï        ?›yÊ?êPžkÇDw   b 12        ?O~Väû?ê^Px`Ö   ^ 1”        ?óõ:Ÿ?êO¸Ùtìs   i 1ò        ?Y£”?êEºÄ(¡—   c 2[        ?„¸¨ÜŒÊ?êPx(¹Šõ   ^ 2¾        ?äZÞ¬?êWÜ#o   _ 3        ?«U;Ü?ê^ìb”m   ` 3{        ?«U9p?êc—BiN   g 3Û        ?¯šÇÕ0Ã?êo…‡·ø„   c 4B        ?>ÿž\6?ê}ìW–.   b 4¥        ?‰œ
+®?ê~Ë"ðBŠ   e 5        ?
+k@UN3?êŠ6n÷s   d 5l        ?Ô8w	—?ê‘cöÆü   d 5Ð        ?=®³/p?ê¯&Òv\   g 64        ?$6_^8?ê›©Œ°÷   \ 6›        ?Y£ÿ?ê¤‡Âºéd   c 6÷        ?„¸¨Ü‹_?ê¢öëáýå   a 7Z        ?äZÞ¬?ê›ÑÂæˆì   b 7»        ?Vjq´ü?ê£×s   d 8        ?>ÿžW_?êªŸÀß*   a 8        ?mï×îœF?ê¥+½ˆì   ` 8â        ?+“ƒ€SÀ?ê›3†ÍÍ   a 9B        ?+“ƒ€S?ê¢ÇŒ¬pÊ   a 9£        ?‰fJaÃ?ê¥Èn››   a :        ?„¸¨Ü ?ê¤ß7ld   g :e        ?Ý,i±"?ê¢#‘ßWÕ   ` :Ì        ?â‹ow¡.?êéMÈé9   ] ;,        ?9Ü#m?ê¤Æ2÷   c ;‰        ?‰œ
+²ç?ê ¿Òë   c ;ì        ?S…?ê¢.€uŠ   ` <O        ?Ê²’]‘?ê–Tà£B   ` <¯        ?O~Váp?ê‹îðÃÿ€   ] =        ?9Éñ€’?êŒzÛHL^   b =l        ?â‹ow¢™?ê„<~Y4   ] =Î        ?Ðp?È÷?ê}jEÍ   \ >+        ?Y£¾?êƒÜËÞø¿   c >‡        ?ùT@e—^?ê~Ï-Åæç   b >ê        ?Ô8w	—?êw"Ë¶^Œ   a ?L        ?S†w?ê}ŠÝmx   c ?­        ?
+ßÛì”XÇ?ê{sÝ,z   c @        ?
+ßÛì”W\?ê}™p{Xý   c @s        ?
+k@UX ?ê‹	^q©Æ   ^ @Ö        ?äZÞ¬?êŽõ¢1™S   b A4        ?=®³/m+?ê˜·?r8   a A–        ?Ô8w	—?ê¡oX3 ]   _ A÷        ?äZÞ¬?ê­&ú0   d BV        ?Tw„dÆ?ê¹tn<   \ Bº        ? ï?¶½å?ê´°3‚Ús   ] C        ?!†Üz÷æ?ê«\à›ìU   d Cs        ?Tw„dÆ?ê’˜TL4C   ^ C×        ?«U9p?ê|Yˆø›   ^ D5        ?þá¤hÌ?êdÂx§·   c D“        ?>ÿžR‡?ê?Û °qó   ^ Dö        ?+“ƒ€P5?ê`¯‰‰   d ET        ?Èìî?êN8cÆS   ` E¸        ?›yÊ~¹?êüò(}2   ^ F        ?‰œ
+®?ê	:¦‡ý   b Fv        ?	ö¤½‚T¢?ê$]Íø¶   b FØ        ?›yÊ‚ú?êAZ=yN   c G:        ?Sc?êosOhW   a G        ?â‹ow›‚?ê£d=À   a Gþ        ?mï×î±?êÁ)§$S¤   ^ H_        ?«U9p?êë‡ùŒÉR   ` H½        ?äZÞ¬?ëïSÎáp   ` I        ?8O­hé?ëÙ ËV   d I}        ?›yÊ~¹?ëx½XÉ   c Iá        ?>ÿžR‡?ëd‰(   a JD        ?mï×î˜?ë#cù@O   c J¥        ?ùT@e”ˆ?ë­Óàa   ] K        ?¹§nÚS?ëZå"#ž   f Ke        ?:ÿ0L$Ä?ëŽÙ³“”   d KË        ?²JJ¸p¨?ëfº‚.R   a L/        ?mï×î˜?ë*AAT   ` L        ?‰fJaÃ?ë0n¿U„
+   b Lð        ?äZÞ¬?ë2Èz€zn   a MR        ?Ú|æÍÝò?ë7TCâ²   e M³        ?
+ßÛì”b³?ë:rÒ×€   a N        ?äZÞ¬?ë>†U”ü&   ` Ny        ?äZÞ?ëFé_È7í   a NÙ        ?Vjq²?ëF.¬Îã   ` O:        ?«U9p?ë;v2±è   g Oš        ?QÈ:$à?ëBQl¿«   ` P        ?þá¤i?ëHZzW~»   a Pa        ?äZÞ¬?ë?xe3   h PÂ        ?ä©ÆÅ N?ë<o!RÉÜ   a Q*        ?O~Vâ%?ë<Ï3m   _ Q‹        ?E×Qˆk?ëAÙ,Kc²   _ Qê        ?9Éñ€’?ë:íIAN   d RI        ?&åâAxf?ë8®qºy   \ R­        ?QÈ:!U?ë9òÁ¿0ù   d S	        ?>ÿžW_?ë.U)6Ý   g Sm        ?É¦b—?ë>®»i¯   f SÔ        ?	‚	%ùKz?ë	Z3\³   c T:        ?S‡â?êôbðìí   b T        ?‰œ
+²ç?êÑYªD£   ^ Tÿ        ?4¸§Ýè?êÇBÎ.)'   ^ U]        ?!†Üzú?ê´T—ÓHð   ^ U»        ?ç9¶v'?ê¶<ã]Õv   ] V        ? ï?¶ÀQ?êÁ(Á²	   a Vv        ?ùT@e˜É?êÚGz”%   c V×        ?O~VÞš?êïu½šn§   ^ W:        ?9Ü#m?ë/?Þç
+   c W˜        ?mï×îšÛ?ë'Nò¢²   e Wû        ?=®³/f?ë4
+éð<   ` X`        ?ry-t?ëBlÁ720   f XÀ        ?&åâA‚R?ëIRQ–   f Y&        ?
+k@UX ?ëMþâ5   b YŒ        ?eáODÖ4?ëM¢f<]¨   b Yî        ?þá¤jì?ëG:š9f›   ] ZP        ?Ý,i±·?ëF^øk   e Z­        ?
+k@USß?ë9<Ž¢h1   ] [        ?9Ü#Ù?ëÛç'°W   d [o        ?
+k@UQ	?ë á¯SþÖ   a [Ó        ?ùT@e”ˆ?ëMœèP   b \4        ?Ú|æÍÛ?ë
+	k”â   e \–        ?=®³/p?ë  ÎÉ.   a \û        ?Ã´ßäí?ë*;ÉÓ7™   ` ]\        ?¹§nÚs?ë8Ú+Z’ë   b ]¼        ?+“ƒ€P5?ëJ
+J„£\   f ^        ?
+rôc2 ®?ë`•.Ý5ì   b ^„        ?äZÞ?ë`¡¡2!   e ^æ        ?Ô8wÀ?ë`‚ƒ]×   f _K        ?S‰M?ëk:BÙln   g _±        ?É¦k?ëu·âSwØ   f `        ?=®³/n–?ë„ÊßrT   g `~        ?	ö¤½‚MŒ?ëyAj˜5×   a `å        ?!†Üz÷0?ëq?«”ƒD   c aF        ?Ê²’^ü?ë†‰Cn    _ a©        ?¹§nÚS?ë‡Ýù±1[   ` b        ?
+¾!?ë€]—I–ó   c bh        ?äZÞ?ëbíäÉ   f bË        ?É¦k?ë}÷“ÿ­@   c c1        ?‰fJd™?ëyÞ«Û%   b c”        ?äZÞ	A?ë|–mÜÊ§   c cö        ?þá¤h?ëpÕþ“.   e dY        ?„¸¨Ü‰ô?ëgçcƒ«Ò   d d¾        ?+“ƒ€RV?ëi^¸So“   f e"        ?>ÿžW_?ëmXjè["   c eˆ        ?‰fJcä?ël*ÃÁô£   d eë        ?›yÊy?ë^Rû8­N   ` fO        ?r¤£JdÉ?ëmE¿is   c f¯        ?þá¤lW?ëo¶uµ   ` g        ?9Éñ€’?ëvøØ7   _ gr        ?Y£”?ë€<Ë†ûÙ   e gÑ        ?„¸¨Ü ?ë{î|²¨   b h6        ? /	UÓ?ë…ªúyŒ   d h˜        ?4¸§Ýè?ë…Ï¯m   d hü        ?Vjq²?ë~VÌÉÝ   e i`        ?&åâAyÑ?ë„KUD•    g iÅ        ?²JJ¸vT?ë|uP™¶¶   a j,        ?r¤£Jg5?ë‹KƒË   f j        ?É¦k?ëŸÔ£I`   f jó        ?É¦l„?ë¥
+VÞ¯   b kY        ?4¸§Ýè?ë/á2[}   a k»        ?äZÞ?ë¯wÍàY   f l        ?›yÊ?ëµÂ5”_1   c l‚        ?¬ëDñòþ?ë®+ö \˜   ` lå        ?–"tÿ¤?ë¸k¢Ñè¾   a mE        ?ry-pŠ?ëÁÔPÄÅ   ` m¦        ?óõ:Ÿ?ë»ÇžOx   ^ n        ?QÈ:$+?ë¶ªFØ   d nd        ?+“ƒ€Pë?ë´©Ÿ/º¥   f nÈ        ?=®³/p?ë¸k¢Ñè(   g o.        ?Tw„jq?ë­JŠÊ   c o•        ?Ú|æÍÜ‡?ë´­D{€   d oø        ?‰œ
+²ç?ë°ÚVUŒ   b p\        ?Vjq°$?ë«ÅÜ¬Ñû   d p¾        ?Ô8w	—?ëªåÒ´×ç   e q"        ?É¦d?ëŸe~üêl   f q‡        ?
+k@USß?ë¤ùðý:c   d qí        ?²JJ¸r?ë‘uÿg5   b rQ        ?Vjq´ü?ëŒÎá   j r³        ?Ý,i±6?ëvI¤ÐÕí   e s        ?²JJ¸s~?ëj…â+ ·   a s‚        ?‰fJc.?ëaÁ/óD   _ sã        ?V_*YG2?êaü…wý¤   l tB        ? eáODÑ>?ê&º&.»Â   p t®        >öÆc˜Ã3µ?ê&ÅÅ;   p u        >öÆc˜Ã"²?ê&ÅÄð³   r uŽ        >ôóõ:Ÿ?ê&Ì^~mÊ   p v         >öÆc˜Ã.	?ê&ÅÄý¸   p vp        >öÆc˜Ã"²?ê&ÅÄð³   ©4KšÞ–ø!¹s}xåŒÛÙ­`D³ä(‹©6	–0E	– ,¢¡c•$$ ›"š2xÔÏ?‡Ò¦÷O¯\®˜©[…¬T¡ÿùŒ\'Ý	vq²    ¼4h…¼Ä2n‡õ8¢'o¶ÆºÝÙ6\X<ˆ˜$6Žœh“‚g‰“©l*>ûâ,‘
+Xº6üËšž{<5F+d½Ð/È÷$½£+Oq*ôZ#fl¼Fx  64Ç
+ûÈuýIZÞ=­y*u,MELM–aë%b@+bÔé‘#’µSdb’Sµ~ŽÜ,¬+W2¦$„¡sø1\öG‘;Â±¦qµ+¡ùLmðêH‘Pà  34à¦NÌiÝq~®df4cFè E€Àè‰ñˆ>@³Â‹‘4.lDTð ±Ppó"b„Í‚ÃˆI52	>!Õë„~±—ÙGã4„°±Ö3ô·˜­aðþt4  \4Ãªd¦v%z„—‡±zT+¥Ñ(ÐÑ	á°à‘ÀÈé–¸zØ¹Â—%ÍÎÝ;'(>'!`T\¤à„åª[õ3IÕÈSGÇ]š¡%©jBínõ[¹ú8¿KL™Êdh’   ;4üïùX‰Ó¨%üÝÒ²Ô¹Ò…["ˆœ›)#’Öê*¼`hõ±QBóòÒ·¤FÈŸ¼!nK0Ë®.¾”³¤z ¼¸!ö®÷mXÒößÈd]æZƒ¦à  ˆ4´1Ö÷-îÜNßŸ)üs» „,&",ø$y³¤-‰Œ¾$#>`Rè¼¸À¨ñ\ÍQ:)‘2×ìÕÌc|)Ã”Æýˆô?H=ÞUå¤å1»/\ÄÅ{ÂÜ   ?4´=‹Õ}ân Æò’ºo|!Íd˜,2 X|rUv¥(7­ª)zð‰Ù;ãÒõ2E¤ëKÍW/^œcÎHë6¢u	ÛwêfâD5bÝjÖó¯F§Ý¹´Ü®KÐ  {4«BÕ*3Ù£G•ŽÊ³>êA¡Û±!!*tÈÀù@‰‘™iKSbÁ!SCõ„&íJšµÒ‘vƒd½©“qˆ>èö ußgÈY“ÇZŠRšb™˜‘9l  F4]Ê’÷Àgfé·Ø^IÓsÃ®FÃOŽVžÜ¡g®ž¹&³n˜ðFÈÀ ¥;×ÅF‰‹æ:™mj¿ÇÇš3’ø95™y‰ÿ¿?DœÕR˜R’Y€  }<D8
+q¿û Ö_¼‹¾ßv[¹–c0/¸4F'&^4ØÙTÑ£ÂóCcåOœŽ™	I
+…‰jœ‰Ï–&FñVèS1*¯¤ê:þ'ôYú†–’¯ï#Šéºi›”W   E4;w §V·–ÐR¾µìe³òP°=‰Ÿ
+‹@Àˆýy‡¤D‹	Ä„*œ±™û"”’¨`¤mˆŠa"'¶Ê„)Íg-L^èNJœx½¾OùˆK*ƒ'ú¢À   Ç4q³–ÇýÂ•DñÇë[0jNÈ¾\ÑÁa&EF$y300³G‹:U AáäTÚÜ€*úÉZ@l²þí7¿
+QÓÑðåHÑ•ØíoËÒ¬Nßb¦%<    ó4Ó7wþ·Y1!N˜µžÑÕÅHP`dHPLÊ‹œTA©õX:t}ÁGÈK0d›r£"-%P˜Üj¾ä	S"¹wCðoŸMÒ™ë!9]ö@•Ü…X“*   e4O¾ê^§z”–v¼îbÉ JÃÁ(&4´P$‡è•À©Û’’Ä™7,'2E0&;F*^ü½`‰Y"´ƒL¿Eh§¥¹Y*>o97­˜cÜnÈ}”ïñ¼„BÀ  <4hÝ?¥êkRc’s¸Ðµl‡õ´>.ø&*ŽLåÑ#ƒ†GŒT‘?'xZ XØ!TŽn°™qac²tjf…b—˜Æò÷dçx´edÅ$¢vl}'¸Œ–ž9ô¤N@À  n4”£bµI]£ºž÷Ë“yZ5vDv$…B¦G&.xtND¸HÙ!ÑJqÂS£¡ƒ„òeµâbÕ.Ê&œPKeåô~¬[P´ÈÎhw©LdcŸÉR3S!›°‘   =4
+Òµ}¤iu{ ¶K…­ðèÆÂ³fÇÄCÃ4.\h<âág6",ð\\<ÌÐdÑ3#Ãj–™”²Ç“)z´†ðËð{ëU4¯¸¥ÚßÔWP{À   ÷4KJëÖ·P_y|:£úsdÍÑuÏTf†
+¡>MÃ‡d(ùR„†D$lË£h¾&^c˜úLÎíµÍ9>Réi{êÚ×£þ:æ…,¥ÜÔ4  '4]û8ÌiOï)ñ1þ.±ÜØV|(T©SA!!Ø/#>^õaÒÖï^©!hØõé“g$„ÉÏ–Q™“ÍÒÁ*¦à¯ÂœHð+LâNK:t$mÕÒõÊmæNCÆM   ?4KŠR¿ócÉ¦§¾7VüÉŒ‹Œª<¨DÈMÁÛ¶,3$x’J‰yYa‚dS$KMˆŽ“š6¾dæo6¿U‰i‹ÅîÏS?€¼Ö_‹ØÒB¿«•£Àº?   !4Ì¥e¸§æÌs3Ký‘Ÿ•bD ñ–CäŽ”‘á´&Î"4`á“‡Ý0PlL™… ›$Ê‹!4Úƒ6kYP%$µ‘zåaÚ/ÉS¡rï¤-xK¾v§  P4ÒçyÂxP™¶ijõ}Nîfƒ’£aÆ¡£CÃª*%*r¤´Ñ#§F¦…êˆÌÄ‰ÙŽ/$³r Ï˜?[áªÄYãWË…¡¯ÈÏU‹m°ýl6`ì¼qD@  4‡t	æBÏ2Ò—†ræNù@Ì`Ð‰À@èIPˆÍp}Á²…„ÄOÇ™ À \:ÌHIS#€e´&J	Ìà€¼äXœ…9º…}*g+ŒR½ÉJuL^«ÒYZ  Y4sªZ›•ÿ©ú+û^[z†ïÝ‡MŸ
+»äKM•—¢¾nnrÙ¹*9bE‡,žº3nø ’bÍþLÖ?	Ñ`{É=NÊß½rz®×hÔfýK©ä   24Oª´°˜§sÑ“A	¿—ÊPÄñ‡C#eCâ¦F4L¨á·<X¸D(p¨ûP›£ë	ª	<EQ¬T%Ëfµ×â4b»n^%ø•{•«Çö·ÆMúf¶  V<ëzÑtçGƒ÷>¹í«Ì¿ögÿ}Q½Û×åÇå§™½xFl°„‰{rC—dËÊÈŠJß2&4Üvnj¡òÖƒNDOz£¶„pËèZ¸ „kÁOfw¥jì=N†ÖßŸ   84N§ò÷õ£åïBÞÑ9~¹®icÔDy³á2aF6\2¥SeÆF™<H€dÈÁGA”®¶,yÄ† ïz²²•@–Óý‹K†â’‚“T¨èØÜCÜ‘3DR®$ð   Ê4D³–ôW:õoKŠÒ¾=Öyq§Fæ„R6( leÑ‹©*PMø¡$Ä>ò4É„H.Ðù…LHg­ª¤±AÝJfæ!®¼ÀÝâfJ·•u.Jˆ  4MüÀõ­éÓ;¶Ú…;Ã‹BrÁˆœO"*B$2U )òÄ “K“\	½2@¹7FI"¨¦G+ùù!î£¸z1…éÁ\—©Ùž´šÔŒN€  @4
+tr¬çµ%äl‚ÓOvÔ•31Sb¢B¥Ásc.0L8&ôAàšC`Q‘!6C§‡Š†,0$dëê³
+qLsçªÝµbvØS¿‚ó{À=ïôíhwú3aY   p4
+*s¼Ã–bXäûVÈðé:öÂp@@TP@>L”YêcC’us&o“Žº)hv^ø¼¸‰˜™aa¢ªB„#\ÑLÿ¦É;þÄ6öFOÌc±<‚Ö3F1GÑÝ…¼A‚@  4p—ôïÕ¯J…Ê¹Ó¿]`ž,/.(@<\ØL‘á‡OÍ8KÁ±aC…ž$:øt«¢¡²h.ôÈr¯dð¦Cº2ûé7'»—'0¯-Þ2RTþ™! ì  4MýìÌV7Vk#”ë„±pœŸ­,qp°t±òj">eÑrê
+2X"PQX±³„ÂÅ°";"œÌªw.ÛûReý…(œÀ#µK{IÐâÿ™K[ÝX
+ëÚ`  %4	6vŽ¥=»7‘Ê9…û¦KªN?(¨èPÈ€aáÔ–½0&!Bd\µàh©Ô¡Yy³bjê·f…	,4É)=™%‡ÊZµ¶9èìK¿¦¿’À
+à¸Ç{o××2  x4»µ»O{3“£Ä-»öÌq™¸è"6((‰Ž”é‘AC7e†¬ŒHJÛ
+Z=!¸öz?SjÁ¬Ï–
+ö¡ÉF¨\©˜v&¦Cr2³&­hìGú%.HŒX  ]45[™jÛ[ÀÌ–øR_>‰ÿ‰ˆT .8"8:bäR'…­Ø¡/ 'rtÀPÉNKXd&1IZÉ°Ðd[4æ¨)O(jÀ‡ÐÞå¦¤+ËwÌ…­R/¨Ìf”à  4¦wï¤¸ßÙ«aN{ÈWÜ½ËoŸ*\ccŠ…Ùt¨Ñ£ »é‚‹œp¸*¥a¨£Æ‰‹wK95ý¸³£[’–2úJ7Ÿèˆi/ð`   4*#¦Öìîj^è_X½Wc<þ“ÃÂA•DÆ@*ÙÐ‚ÄVº\dÑ‚!WZ"	‰˜L‚36ÂÿkÏ¬••³ÞùëABÖ±—³FGý•{ùZß    ì4%ï´$°ÛÉy{¾˜¡Æ•>`äXëÂBFŒøê·BÈâ6Ù3aƒ­Š¨*ØÒ±†Ì<u>¦Huùí«;`ÏDðã»…<V7îÕ¹ß¾’Ä(`  !4\ýJUlsÐîäêî'_×$dUšŽ…ËFEF	pY¡’8"uòàisÃÅŠ'*l<&¶ÃJÃ¢5™’×TÍm=öXÏQÊ½iÊ‚Ùd=ÞvñRYð£À  Ÿ<ÑÐ{© Åw’¾ ÇOš^~ÎHM:x€ÜdT.0,áêÂwåïˆß•œ«’ˆ‰DÄ’–çb÷hÎ!‡uÌÇ¿H_±v°<²znV#¬%âÝ;Ö½¨7¶0  g4ÀCªv½™æ·&¨©hC?	Ã‚GÈ‰@ÙñÉÊ”V¿1XõÁ3B±
+Âób²TbÔÒ¶}Nˆ‹ ÃÄ<©^‚ËF¨D=7¼çR3Ru±éL~7…iã{!öà  4"!G¹kènŠ{?êj-b”dpð‰éA‡‹”&Tà«#A“§X<"8\Y%€“-
+Lg•s†¼6FNJíO­½KRyõó+W(Þýl©!`   4%¨•>÷”ÔÿCXâ¼–y“ÅÃñCf^>02âB'Ú>Äë¯‹(á1Ó„Á
+®X ÑÕ®0¸ÄTçgøªJq
+a7îmÚšªZ1ÿ÷ŸÈªÀ  4Çì…¹»g#ÛX¦ä¦YqZI‰b&Â@‘„4LÛOŽ¦Lm ñ€›¬ï>£ÛFMð$S–h¿ÎŽ3–¶5j[L£¿’¹»Ùë*¥(  64R…ÖlÕÜªôæ¯^Ä–¼:!dL:0p@w.HÏT;,^X‘ù™I2C¶†¦Ë	©š	,Ó’±š“ŽJÛ
+E²…ù/ì”žÂ×çr^g™JÿÐÎ¶âÇÊ†€   õ4oª|W÷,‡y%kƒv0DÖ¯ÇÊ<.2}‘‡“.@ˆ±V‹ YÙPÊKƒ-Y4,I3ˆL¨¨‡uh4Õ
+ñZDº——ü´¬†ìÍå^Ÿú9f€®äµ   Y4a¹ú}Ü­ÈSï¦=”üµ/† °¡ tD$9cÇ‡¬IÐ”¾-´ #.2+=\XáùÑ£Ñ"­5Ä4èrDá¼¾P?jö8Å§ô§%5-´%;54½£ã£¦-   /4Z•xŠZ¦Ðí=†¤%NÒíU¢•‚&ÈŒ (`u{Åß‘>: |¨Øp‰1¡EÌ„
+‘.™±—VGÒLTZ•™mÒŽe[:32¼ð[Þp‘àY“%€  ƒ4Þ!gêé
+æ!;°5'-hŒHp4(	ñÑASC'ÍMËŠŠËž6r>@°¡11,*"GÄc(êOK³ÉZñ?dhBr˜1)
+T˜ö¶
+\Áš:ê<š   Y4oi¯$iüÔ%ˆ‡ÞQ—¯Ë´=V\xèØP,&0Dwå¯ÌÜ "VlTôˆ˜´˜ˆ¤ÁÁiC”BÇFh±L1õŸà„µ’Íïx'¤ÍŽhËÄ:³;CB²6¾w9ª9*l  4EéÜ§Ö²8;cƒ=Ô¯Â{—’.èTpeC£*HyÅÊ™>é±b¦ÄDP`€ik‚È£½Ñ‰³!âd5®^ÅKÜ±B\R›âJ¶HJs®¿y-.à  u4M»·z¿WøþU¾ÀBW-ÎãþÑPD¨@:.*<:òrA&KJˆž›—)v7#'ª™$VvvàÝS;1—lJ‚ÑIhJÊùÖðöu¬ùÕÈw¯âR¶þnøô¸  a4wª¾JqZ~ÏÁ:WA:)Y§’‡ÁÀˆ¨.8l~KÈ‹†Š¨–(8":$*&%4Nl%p#@Bl^B¼¡­ØÜYÝ‘‹Ì-JŒ¼îFý„w§nR{k’ò‹ÉÛ#þO“S€  D4Q½´Ç4‡k55°[Žòó_E„ÅâÃAƒDG-#@vZ¡¡Ö„oDd
+ÉÞ'09r+G½`Œ¹³dlúmTO§-£þÍKa¤V[ñ
+-Äér®JY2pH   ò4§j®æ+ï½úáBý.ÿäêÅŒ’, &hH|g2gÁDtxhˆÂãÉYƒ2FK#6›ªExù¿)ÉRÞF·>
+Dèm#é	N3Û/ågãØ  r4-äül§´«î‚v½ß»¢PL˜É`hP	ˆ¡Qëâ¦dÊ‰Û$*’²©n',z¬‘4Í?:$ìïa]OT‚xãüÜvŽñjÕ¯SÝO™™Fé   4!b¥}ûÜ§_í¸cÎ#j©(Ðˆ€‹AÀ“£<`DÐ£$ÅD–6ÐÀ¨¸™qS"éX		,­#c:ý‰‚<õÚ¢¸„¨dÔ#‘oªÌw„r¦²>ÒÏ…%V2  L4cêUoTëÚÆ1¶•éÊÄ6<Yð ,8@L[ª!nèá©“‡äÍÈ^*¡7,VB•kÁ‘SŠÆ¬æpßWgt¯ÔR­ÏsZrºÛû+ÅQUï‚@  W4
+©fœ^(V˜êKêñ«jÉéxB: ‰Àñ±[â”„…N›ˆÊÔ<+4rB"X/M\FlTízã"›¹©?$x'#^R¸Å©³¥Þþ+°çwu·Gaº±)@  44PKº\Ém­	Þèønj‚u~ÄŒXL"xˆ&XPfÇB"…S"(pÀá1@¢§‹„HIŠ‹Q2«C2é]Ú©es×}ŒI«#3ñiU=„¨~++–j/zaà  M4^¶7{™ŠtcX¾LÍÙmÛ~TP(&:(44<¢’GŠNQ<$:VRJXˆÐJP©ØÕS3cU4êöŒYOúW|‹	}ü{ÌÄãrWêÑ«	Òø)ÇC8¨)v­à  B4.äþò×±ŠÝ³‰­|ÜSÉc‘ãas!!¡ƒã£>lõyÛ×$hNIJ’“k"vd&bÅâƒM¢[ôDVŒ„Ç×„÷Þ½9é|"–µ–äõŠ)Êu„ž   Ï4¡×žÔòO§m~FSnÁ\D´\t a‘‰œx á¥KX*ØDšÇÍ
+N°q•Äƒ¤É…åk¥M…/²!´fØ±¶
+Æ ˜"‘Ÿ~O®@  24
+¢!G¹›ù˜Ïº´DãRjÃÚ1±‘R‚§Âæ†>HÀ4±¡–IžT¸èMyá€AaQ&H«3‚Ú<Ç§'WàÏ3\ÿÒÝZYÚÛà^îóÐµyw   $4"3‹Ö¥oóÖR¸ÿnCvÞ£ë’çÃM„Oâ¦åÌŸ”ªxJ@ü ¤ËôÅÅmNÙÓœ/jBÙÌË Bƒ©1•)O‚v§³HåË=Äæ6/1î’ÒYøË   f4H­ë4-ÛªBK°ÿÙëSoÃÌ…ÃÂC¹fDDNLnÑÁ!qÉ!s¢‚râFCuKÊX¹x€b?þ¢S¯‡y±+ýo`ÇZ™’¥”Á8§[Œ÷Hg÷`¤  y4JûÞÜ¹Œ1±ØŒTj'¶xð„<dH62L¥Q9ù#‡­KOÎ…+UŸ<3~0NÀF-^ôˆÐÒÄç¤(Û wØå~‚Q‘Œyn7þò÷ÎwÈ¡qHX  H4+'ßYü¡1½NÎ«¤ÆqñÖØNƒÚ	ó²Æ,›•2vd\nV•¡ªá#s4^MÄÌSºhüh¸CÍÑIYVt¿äÎò4+Æx«
+t!OîÀYÒ!   4ÐóÒ9ûà‡™…ëížÊ³Ôt,Ú ÁqÀ»#><ã:,X¸ ÓÁæÆŠXDãC(mì¤/¥i	-hLÿßõdlqß.7¥Pnaø°  G4/oYW±žVºœâÀ…’Pxqã! ð™Ñ–$ >háQr#B"AÃdŽÈ”Š‰Š80<yiÒ­`¯ž4ÍELÈHuÇ†úÑ«3íÈåwäî™LÍ¶K€  &4àÕ
+ôµ—ç¼«Ä$D: æÛ³:lh€ðP,ùÑ…Ì.8P‰çE†ÄFEÄ<x&à°³.ƒbIÕ:øÌ§­>]£iÉÞ®ëö¡ëQ½1½Yïó—±LÝ$(  4?µI..Ía+µZZ½ÏÞ1bÌ0> 6&9…«ÒrwLK[¾³38fvbõYÙ’•‡‚G‰Í¨˜úXù~Ü“·VÍš]ÆùöV#ÄNCã²4×ÈUš@@  –<ÑUì¨¢á_ªƒJ¢Vµü”ðÌ×<ØÙ™ûãp¥Øˆu‰Ÿš¬1d\ØX!9°.46T¬R)hBDåpÂ¨-O3VÄ§ôWÀ-ÔÕŠÚÓ†ªIÂ¸$lø!­‰Ó2Œ  ·4îGøKSªñ'‡ó<EüníBq€L$dCƒ£’´fzv¢€„Ø¨èØ°´àé$PFš/[èJdPf ±°ö?kÃ-¥
+fV}…¾ýh¶Õh¿ñÔ)ÂØw ªmAüwŸ2   ˆ4Ääœ†¶/ÓŠý‘\*•\º-&‹ŠÁqð¸Èê[¶/nœFœ¼L^ü¸˜àVžPLÔíI1©ù"‡å,ÆÑá“åÅ!Y_-Mô­ìF´	˜å5ÃP•gÁ:c-Ú€  ^4¿+~Õ{Ø’Âf§.FwFµx‹†ónøÜÍÑ"Õ‡,He'.´68%LØôD¨Ý€ÊDTV”åiý‡,HEé”‘ÒF7ñN”™¦)W:  (4ãúwä9Èä‡dkîVr¼+€HAA³ ¡a„Ï<žZX¢Á#¦‡È<*:	2Pi¢„†—Ôb«çÙ
+7£9×^ScFµ	JF#[o/5l­}eL€Ô€  Y4'_1J2³œ÷^†¦þM]¡
+‰>	
+‚Cb®4^üŒùIz’³³‚†D¢5¢ÂÕ…m
+Ý!¹(m1&é5ÉSÒ»f¾æ¯o}áe³­¯­ªËZ8  R4¯ÇºTå2­¹Ìäîå¸­5+Á#"c¢ƒÃ¡±×›"xXLíë×å$¤$ÄÄdÅæ¢¥d†ë™ˆ\,j@äbd§ìAÆmÔžècÈ„ÖøWŽò-ç¹Ù‹e®o-T0$  q4hYÝ$¤-›t#¬S­÷¯SòÁ€lðìÒ·zÔ±CÓ#""'„Å¢7Ì”HÄéš1f@2îIQ"§jµ5-ªq**c0FHVåÿ¤§""ø„‘U`  $4/Vžõ/õìWD`;g„^­Q¢’'ÂÅÁƒx*M°³¢TŠ
+ï*|&È aðËñ ÈÉ	—ÌLA¶?_€Œ¿a©ªf,NÒÿi©|Ää3!#[z¹1f‡`  4!wšùU¥Z_s··ë¼]ÿdb!‘"!Á¡QA×‘«/+lý«2¢bƒ¦,4=IH'GéÑ¨©+%¦&µ]é§Úfh‚q|«áûéXSÍ¥eðØ+9D§zI#¨h  ©4z[X–Yj‚V¶„49îfÎpØ44AÐ©ðØîœœ9.+pDÄV),.2.0ÚŒ³	^•:lÐ|ÐxhiÅ«n·V[vâŠu×j1‘õ¡¦ýàcyLKWÄY¥°H  4¦~ÎU±kÉIÌÑ5%žoØªÊ ¡Ñ¡B£>``™¤¤I˜t00ùð©AÕˆ$èpx‚a&ÓÅè4·Y©où<ýî-bÅ#‰NaÀnbê²úÄ€  ]4Ë0‡¶|ö3FP' ´­Ü,Ó_È°àx<QÃ‹Éº8nTPxh°ðÅ½›B´OËŒÙ–6#~5úÕ\òÎXÄ^ržÝ÷^¡wqÍËCŸ”‰È­Í³Ç   &4À¶Fä²Gùµ”Æ´_“¦¾÷à¸á’¡à€ðÊ	Ž èÁ#§‹œ0.*\`X²ÇÎ…žuÁ‹¿òVâïŽ×öWÜåê]§Goâ×k·Zvˆ¤I]€  4~Î<Þ*Ùœ¡…ªrß)º	Í™8ÈxlD àÂÂÌ…‰¤LT›'ÄEK:>p.»Ãï: 
+¾€eFaýÖ!ç†êÊÿÞ—nðËŠ•"vë7;R‰ZÝˆY‚   b4#[XŸÕfö#Ó3•ï{#ñsÞ8t°:ŒŽåË²RæîI¿,5&3O|r=Aš`±I@­3ƒuëF’ÒEÐ¦Ø¼¥ÉlÔî/R)Í@%‰xÎ¥/Éh„·O”  '4ësÓ‘òÕ$µ)1¡#Úá´ DMãáC£‚ƒ(±sÂ%Š’4&pH4ÔØ]H]pá„C(> œÄÑAtòQšV¬Ø«ßA›YÓòoaIr5-\Å=æí£(À  P4r´—yßµœgj!¼|{mÉl<6ØèÁ`hH01Gbã/>¸i¢Á“!BCá# ªç‡Ò:>@Lëó0E­v”c>åæ®sÅWU¥x½ì„­<$jÕ;ýµxª°  ‘491X!¹Î/Ä8¿NÞYéCŽDÂ£âÁò@Àè`uçŽÞ•±1,Op^XBLR!#$WÙT'’½("LÆbfP cq%‚ó×¤4¹n1Jn÷A}fdhÊñ¦Ýì&S‘Tà  ¤4­kÁKýÝ™ŠàçE#ÙT1ñÜ¡qÑƒ¡ D0ˆ¬”ŒØ©ñšÄ"CröåîÅ.ÂT…ƒæ\ÎË˜—²¬[VèåGÏÈFð•‘Ì˜òR‡¾Æ§±§~´ GI~qo€  4Lõ™»ýI<LZèí^qcÝx6pPlð¨°Äˆ&`‘EBgÄEN$x06hhúÒn„0ÀˆÕVŽïu*4"¼7v”J†¾_Ï©ÞwÞn#,¨Æ1ñà  ú<›Õù³Ä¾×Eµn›ß¢%•?Ñè5ˆÊ‚AìŽËÊš˜‡Æ¡‘QA9:pðé³#1ñYIÙž‹—5º"ì¬þYþÙ#Ê,µÅ²¶W*omà`¦ÂëÀ  …4[û
+ZŽÊ•˜Gg£W%Jâ· ¡ÒÁa€ðhx*;3Uååå+NW“™¼8p0|`7c^lí¹pÑ»—ŒÔïXy'*-Wh;_9Ž¥¬KD÷˜È;ýyYú‰KU—âV:  -4Ëû59Â_kÝP’¢9Z•ç:á’ÃB¬EBbF†tpe6ÅDŸlp"ØÈ (­Á§ˆ„(2h¼Ì©)m|m2ôœcVíå/){
+_õ=5‹aj–\µ^T„:  14ãúodNÅ¾£¸½‹ÕÔgeË &0€‘#DÛ8péÂ¡AfDD@‚9Ž‘4h*a“fÍ\°Þ$vbgN·©Ööµoêrs½ïÙ¶­Ê2aƒ4  84Vì¾–õ1õ»;Ú„ÍßÑíâ„I…cp±Ñ4%Ž6pÐÐéSb`¢³".‰”˜P6³36O‚C’	¡ä½|®ï-Z”…;ôû¥O‹±I†d¨Z@  Y4ÛY,¨Ý§VåŒþ7-^˜¶O2pð0Œx8ÈÂ¡’G‚©Ó>2xá@àm£SáÄœ	´,*Ë&÷ü=P*Û§ô9FìÕÞòòv~Ö{ŽMÈ—µ"3”)  n4©¶Ñü¯bŽu¦ôµs6ÊÊZ"¸X$,t8qQKBÆd%é;‰ˆ]²x,^~¼¼\³AñËuýŒFá
+»N›¼ƒwð³bWÈÍ&;
+WÞF„®
+ßü^À@˜  ;4t^å/jõ^·¦öµ¿ÊsŸ&B£E‚"ãÃAáÙ1|PBõkãGH‹X!0D-?sbfp½jôc"ŠÕIamy|[}	Ò·ZäŸ±¬Mi~¬RE{˜Æhh  œ4£Ô…¹ê_Hð?÷¦é1îµÄ‚ãï3 \>Øâ5f†«ŠÍÚ¨4 92!-ÒQ¨)œ¯zh½dø ãvKO-OêŸwnµ>÷~«Ëe9£c[eé3-]ö   84rgA;Ø[£þ“XlÎÝ%kÕ"„pëÁcÀùuF	p6ù!ón¾ 2è˜A!`ÉðTÁ—Û	
+$lhÔÐ_i“œYn®à–5éi-!~¾KÈHÌú¨NKõod*"¨  D4
+”ÚcS²Ä±vïqN3T—K2àÈT©±02tXvŒŠŒ‰¼&rà¡‰Q‚£§#Dí˜’Še|hÐjZÑÒ“¹zœ)ÇüÜ‹ð=s†å"r½šŽa‡û?7¨=  <4ëú:»¤¥ì=f•[? ÑnB‚.
+„Í„CÆÇB¨Ä­³õ¥„‰H	º(Xrh´pÚ¬B«©ëuZÏ
+¼$F z@^bGŸþ±k˜GŸ%½13ý‰¼÷Ñ	–øêÐ  4Þ[mSºô¿ã±¾~«»Š<PT6", 3'‰ŒºØˆ‹H²	&x" !$*é±©ôÍˆ‘›‰lÐ•d¨¿79dý^,W³FžÔejí+vÂ³e8°  44ö´…+Ý^À—ö$m’§³›g`Á°ƒ¡€«C#	$hÙñŽ4$Hdðèq¹Ñˆ„ƒ,XM	•[„t0³_C¹ãöñ¯d)ýÖÑJº‰Xó2à#ý  V4	 ÎÝíâ5öÞJ–>}1‡-Ö´ÉŒGGBTô…ã²¶B&„(
+ÈŠKN“ž¤R",CDn‰¸Ój­WõqajÓÿ•»ðí*Æ´‹Û¦5'oœRÎeÿ¾”  d4`7F½‹T¶“·Ô•Šû®™}Ã"£%ƒ ˜¹ñÖ°/3h¤DÀ˜œœí™ãq#‚’&ÊÕ4V2Ç&¢NoÑrÑŽ÷<§zJä¾ó}_ŸÔ´œR@„…á‹á8B  4Ï«4óÔ´‡¼IÈ›¯ó¤ùèH&À€ÈdI	Ñ•8>©±SGÚ&,,È™0±Ãa”¦I²PdY!¢éó¾Xs4H©~%z,ýR¥	¬]•ÿÛR9öC-]¶@  4bÝpÛg«ÞäÄ¶†ó£æ…Ü<&1‘…Ž™&pmas#N>88«Â¢hˆƒÄ*¾ÈÕSQUBv"™R÷iKQ?\Îcí_Œ`‘óú8€  V4Vsn­Ùûiî½	óSš™à{_‚¡cCƒ¡ @@K–:1*ZÝ¹9k32µÅÇä‚ÊLœ©z8\ÈÑ
+1´`ZPß„Ü»Ìï+Å*ÌõJK0ü8„ìØ1Å)–¦a  [4BC{Tü»Bÿ>ÆrÜJæÈÐ€˜|dÀ",pTÆfdY³"!%"dZXØÄ´ÜJ†¸Áo"£RÇé<5Ø¤'"š÷ÿ…ùâÏ²•"ù{¼œŸ÷îÊ[/ý	™žl  >4+å.ªËHs¥Y}Q–ó¾Ý»d>T$2(Sâ"2¶îW»pPh@¨Aù£qã›S6Å"ä
+/Ö³!oEY’u¹¯‘+zMÂU6×8•=å;‘ÛRùJ¹($  ,4©gá}ü­ýü“žÕêŸå®µ,<*6">2ì
+º@$–1Ãç–2( 8H`ë'Îƒný ¬Î1fñÙ…ÎáNËÁš¸Œÿ©ýíÔÆíët3¬S,  T4ÄZ­îgB•Ív3#K×ž–¾|àÀPt`|dÚ:PXDÉã‡ÇŒ‹>2	™*.RðlEbKJíëw—ú+pÏ0Ÿ–°·^K)»Žk`¾‡¦S`¡  P4ÈfGS;^»+Ôù·Ä–+¿È“£¢ƒA‚à˜éaÖ–6+nØÔÛBó2Bb·ƒR‹sU¤"ÔIL­äö¾[–”ô£_¹:ºd«VÆvGâVvb„„Ò²2v  4
+œ‘Ýï(é)÷änqB[MBí@©1Õ…‚‚…CCj¨$…Cå42A@±ráÚ´Ìš"¥¤ùWF¹¯÷R–ê=¹d)T»#¡ª_Òì^¤ŽKÐ¦)”  N4Ö¶Óôµ«•ÚÿõÅ)]Ì„©áp¹ ˆ@x(4;Dåš“<RPpBR@L¼œì´±q™"ÆçGë;*£ç+¯RiÍ„hÃjJZCé[ºó?1ø'¬<à ¡:‹@  C4lbÇöhá´†të{”Å½ŠØCqÃá ¨à±°¸Ëˆ„]*À¨Xa°ÉÂâŒB¢"dƒ'’’&2¯#
+Žë(ÔžÔÑüå;ûÅ¤3¿L'ÅÙW:§,‚Ìä   ô4@w¦lí¥InQÂ•»¸“#‰2#¤GfŒ„ÆU±‡Ûxú#A2‡ÄX62”DQ¹c•¼&Fcd$¦‰æâ§qÿ‰yNt·zµk#’º?%OSÞ5*‰:ð   â4”œ°üÖš’—ìŸRóŽ×Ò#‚'G\ª1ÄÖ	¬±ñ…d¸ D$©q%$‡DáE&UÂþ3]=Í{#_¬ä´'~•š%eùµ‚»ÄTIÐ  4Ï6¦-ê÷•±¡S¦¸YõJ²Oˆ›F]Á!CÇ-\\Ñr!""£A ¢7G’“TQ–Ì¶²¶7:¦#c<¯íI^çëc_á9ÍJÉèPFO1a1§@  F4ëº’=Öû.¡ånà5)ÒOèhˆØðø&2®>‡E
+U–•£`DX@Ü¥¸”ÌÀÑõÉÒGÃ‡‰ùª~4Ó³<rêNâ4# ÒðÆiÝ¤Šj#f®…Ä)KO0  945_o·½ü¶bþá!C‰ŒæÉÉ—ƒã¡Ò:&#nÔµcÂÂdW,‹ÄïVMX2·$ @DØŒh+BLŽMª%¼{q.s™’÷JøewnnRÞC  b4ÆG)N¥~‘ÈFOåïÚÏõ.,0”FÇxÄ¸ÑK‚w.HÍ‰­>–%!0F%:=Iì¡ÊÁ¯žƒR.8/Rì•/ãÔ¦jûW™ù|7Ÿ±xWÊrb  4Z¡žÖ•ÚTª™¹î†6tã‚çCb+›@¨‰q#ÌDlYq0£Cb#£l"\¸øée¥Ë?7VöP´’úØð÷µg¦©ÚÆ…ì‰Náõ¬8ëÚÅÎ<  Q4rkPÖ·f%ý+yÌÿÇ6;l4iàñàxÈ¨êÉ˜8X&KìØŒà˜‰Q ±x©“CE¥¥…Eî¥(0ŒÑŽªÂW°·£ìZýz–"ÖŽÉ™³Ò}w)¢  [4V³šMèìÅœcµ*P×t.OÈBÂá¡ûp.Q@Ü¸™Ëós´†*œ‹V½=+zRº¹¢!°í1 ÿ¡B”32Ì„½‰Ù[åªŠDèS!‚²™ Â@  š4wß•³ö-+ì¬žQž+Ù°Þâ„@«ÁÁ`Tl±1yQcSeš˜8? :	L‘Ë‰Û
+Ø/+hB3œe
+€ŒÈLç²[\HÚœ‹f7”~'¶r^ì7Ó-˜›@  K4ò†'iùÌOšõr!/ÌÝRæk_Þp(Ë‘BãÒÔÌËŠS)4rBh#xd¤D­	ÃC6doØ4\V‰Þœ%–@V–Âµ®Öµsù®ÄÖŽvuZb{‰µ  d4
+NØ/¼ÖBûÍç+´‡õ³ÉºÓ‡‚  °pÈêžœ=bHJhÀ¹Ù1b×ã÷bEÄjHNÌS9ho1ü*	á:¼å áqjqZr~HmR%#€õúÈoÔµ)ÿ€  §4öSúÜËáb¬í‹™ý#F†	ÝŒ‡‚`É` TvíÄlÌ—-,;(6HbJø1 ªj$TPhHåa[²1‘J!xï.ð©ÖP„µ@¬Cç£__úJSÓw,Bd  I4¡o©hs)!ÛV¯ÿ^Ä¸™ðØ`T DdvìLKY;fäÅ1‘†¥JÏDe*jHŸ‘«RÔ´jÕ­-dW“šE«âŒvV°;ºÏÓSuH_¨%é©naˆ   4ö†tJñ¿8ÈP—ÿ”MiÆ$àéQÄ>*6>‰ÁVÆDá¦çG]™.\³CL3PYß\äs¨§IÒ’ˆ35\ý ¿XÝ‘«"3Ë1Ž£@  H4£žrv)_ëTnvfJ¦Ö¶*`xhh"2Ž•¢²#†èE*ùœ±&bB,l1Jø‘Uy™Êv±"<¼k³ŠÒ…hþN¼­Il%¶˜öÅ[Ó“çyÈe¨h  44nKE­ñíjuéàåø¢´ìøÃ!á ‘³Ã˜$tðD¢Œ,tØD|ÈÁqâ®Iƒ%“Š[Ñ“Á1Ñévt=Ì!ÛtæíÛ£#®Öek~r[š£?•f¼  4#[_±›þÆüg?¥ïÂœrÄ°ÒP“aA ¨Å…Ý8eñ!Qgˆˆ…K“ |pmPò›‘•±í»L{x_Ä¯ÏñNBS¿Äzê÷øÍfPÜ¨šê€  C4=• ¦¢Ô}µ{ñjiÍ-P062.ŽŽ‰¹+‚÷(ÉØ::3R¬¡`¤˜„J’ÑCÂw£2
+Bf&7ñ²<L{È1ea(•\n°‰øÆÏ\Ìp©©wt€  N4»ÎÒ˜^Èìæ§}»Íì¶ÁSR‡ÆB‡‚ã‘òxx¼ýÂ£¤h¤æjU5:=Xf¤èýÍ¡I“”r‚A¹?t©IX”Ü
+WDìRbÄ¬Å ¶á«µÇéIÙ'…YÊyH  /4ú·7}Êgÿþ˜ã¢òžøõW%_"Ô#ò¢2EKÄ©=—¼nTÉÛ[Óu¶k+Ì	Û’7IàhÐ¹>vºŸäØïv¥hÈNå™H¿ßvß¯|JJ€­  ‰4æz•+|±b[ÿ;¡j¼œ1\2	‚b`ƒcµ0 <zLjí»òÅÅ'"2›'¤FÁš’Õ~ÇÁo:“û¥üÊj$U¢-9ª+è2<²µòESKÑÜ¾%nI‰   4òÆ¶êu†væ†=ý‚×Ë•.8 \dGdH ¡v(} ˜Ù…Ë‹¬d(‘ØÓå†_åEµi"•¢ò$/ÑîV¥Ì>ÖoÞ+Æ)sÿ¥lA=€  E4(
+bN^¥l²µ¼•ì6˜ëWÈ
+‡øÙÂ®	„Ž‰’0ã L˜@,…ÑÃí®  ÎÕˆÔ£Df"½îðv¼:9œŒ`ä#òFë‰É¢
+Ð  4ßdmxnOÒúÉÕ½™=òÇ9%Â"Âg†3ã6Q±×&Ü\.ð’æƒÃkd/žTÐ&yÓgÖLl¬Ïc³Y
+käŽãÔŠû€äŒÑ£Gý¨”™ªÍ¸  Q4þ¦Wêæn_·"¹U£cP¯|P€ðÐDà&\vlÕŒ¥~ b¬È…yS¦††Äb)’Úá²g)7’ö¢‡¯Jód·òXõj#Ôç2'j¼Ô‚ÕªËñŒ  e4z3­û\
+{N`Bðþ9š7z`&"àl||2tt‡D&T¿!Bh/b”¹pøˆ@ÖFfÞèÄ^“y².#FS(±›e45!ÕþkÂß£båùž¤°³DG3’
+‘–  44#{k}U¡%¿»Ä3'ÿ‚2ªLM²:8˜P@0¹‚ƒe"@$FDHÙ": ŒMAA`IªÁew=0+AJÁºÓ;q¨…zQß‚<írýbö÷9>Jeë›+  4íb­y>®Mù7±*™–©MÎ$‡Ï‡E†‡BAPD~ÝŠ‰šˆ”˜••#ª‰ÎJÛµ#j~^#LJTÉ`ÔÎ¤H7x°¥XÇBþD}½qrOò°B˜ÄÞs–?2öÎ¹  
+4'æ†¶žçœG3Çº•ìÕ^ÀÔe	2Ã…ÃD‹d@±Áƒ„ˆ°.~Q0¨eˆãÂ‹Í‰’*MdÆÑ.'Wc‘.§r_È¾žÄ¾Àæ_—óù.\ÌUiâ@  4Õä_i­V÷Ú4«ìw.Z®8"Àˆ|¨€Å•hpX‘×	…‘‹l¸˜èER†Ì²4KÐŠ¹Í³˜Oé†2÷B¶0YÛtæýÎK©>Pëyza„@  £4¸”îvõ®LZ³”¶w;¼Ð9ŒÀðÈðØ lLtÑYú"‚AC"ãtbÕ¦&†§äìÌÉŠLŠ³%Lìjan	ƒÌqÌŒØw«¿Û†"ùbÄ5ns|eýIn§À  ƒ4l­3åêšÔžÔŸáÞ¨UÑñØ]ñÁ "@
+.‹£reåŒËW6©2D~nìùëòö³ãw­U¾Tømnv2â$s´ìÝ~älÇäº»jçÁ=Î\ì“DŒÁp  94#wÞ5§¼ÇCœÚÚŽ˜`FLHtp@T$i
+òÅäÆMœµhnå¡¹©ÛWä©«O˜'©VX5¾þ€r#ÞA^ëy›Ü³w)ÄójfŽ.Û¯2i–€  C45!ÈKsIÒ»È®Ö>yD„º@ }°D2 0:öGN’½ x+fJÍP…ù1 íÌ‘óB’’Bí˜‘w¢+.Çßçñäz+—RüDok?/6œÆ¡‰.%óE¨  ;4³¶SÑ¡ü…{ê:	éÿ¨‹•0ŽÃ‚cÐrHøÁcÂg¦ÍÜ4(&13)§)jXpzŸ‰	šyRlbyÐ–Â;èäÐíêÿK\˜¯sE4_Ù¿@™p  +4õ®ÓžVÒÖÕ0¨-#¹éjDK¼0™/xè¡±TF<e±Qh4U±a§JÂï1`hDkß£Lr:®§¨Æ8#r”®€÷ÝQÞûy*c{Qvez:ä  Ä<“PÚjóÇ…—LÒžm¶ã“Ñ¼g^%Z"„CÁâ–‹Ôœ¸14t/R,90Œ¯9ˆ™².#'Í¦´g¶¥6c<¢]®l(sXÇ™	¬ûYtIkDWdÝç`  24Ïú´r¹B¾"yOIð›ŸTˆˆGÖ:	 ÏŽ ±ƒÒ÷hmÍVÒ‰Y$%r$V(1U"(Rb`É%JT£R±Û&©£°Å^j=BV3B×ž†-m#çCŸêŒÌÖ`  T4;s™*}Ö©”Õ/ó©?Ï–Vdè£a`¸Tl$\r„„e¥	ì\5"7'vØ‰à´Ñ“†ëGd	^=Z„l*~šTRôí}íÖ¹#N#_¡ûqçnfveä‘ƒ´  K4«öÑZ8HsÍ‹v:#w8“Ÿ.>.0;ÕDÌ‰
+È™‰QÐ”1'./&|LdÉó9™Òµl‹ÒM¢Ó5\ç&·^'Z1È”¼Å,Â—nË…nW§IúRœá8   ‹4§b¥½£µ<ÌRÝª—»Í+Ñ¨ÂÁQ`L"
+
+ŽÌ­¹CÒ‚ƒ‡ÄFåÉj
+MÈEj†nÐð		X²«R6¸QhF"³–ôµ“›‘ê5VÞ¡Îð‹ï+ù½5‹ô  ‹4rò3ÞùUµ^×•ï|!åR‘fEƒGÁá ÀÈè	Ø“ˆ
+‘š­'//jZø¡xDxP’´Ñ‘¨…s&‡
+èÆîjßæÍ…<Ø7C ¿1/`17;`ÌkBy¥nN%@  t4Êc+“_}OI(ä‰x¾)ëDR:à¸‘ÑÐh°ðl~Þµ:LÌ´ÍÊóF‚:›”¤znFõÁ[ÔÕ®˜ßd ¨G–K_²À[)&-Üôj!S—"4ðK:st•’à  4
+ð3õ‡$"tG´„3^ô†(J`’GARÀÐ¸éËÊÒ•´1$P\ld£ä±€”Åé ¡A!©Dê&“"Ñ‘:†Zœê3vŽ¶qä~•À+Ý—ÀÞ{Ky¼h  Ä<6ë’â-ÍÇ•¶Ñ–dµTK_4Tn(D3<*2ÓÇ¤ÂälÈMR‰Û,›»( 7(VÜønÉ±Bf[_$“èP¹„z­Ì!™xÝJûêMà-#WƒŒFèÑx  ³4mÛhŒµ‹˜q=ªþßé½§‚âAÒ€Løp`vÎš•Š¼&µvvÈ¤HbD/JnNEz|:_`˜¬ˆg°³"¹†?„¶'F3µ˜Ýº\ÌÉwÕHÎ±+H;1j¢H€  u4v»FßÂ1Ö•|.S±@ˆJlàD`p"hp¸ëŸ2*'(dBH´¼¹cÆf&†Ù;’ª©xÑÐÜ¯¸‘}ÖóbÑÚý=?kš7kT˜·êÐ^‘½Ð¿)É¸@  ˆ45/-ô­Ì§Õl^ÈþVáÆ	çÇA³Ã§'$$?@ôÉ(±a™Ò’2£#ôÕdÊLŠÄÞ;`ømÝ“‡ˆê6¨3J¿ Cþ¡/C˜ó5¦zc¼-qfXhD  ‡4<ÀüOi=*Ià'‘™mëæ³³#/cB@ØøàP›2p+fvPš¸ˆÝ»ò2²áã	
+2Ò‚Ê„e	Í-¸BläiRóÔå¨‡<‰ù˜=-·ZË8
+`W!^‹ÌBPP¼   4<k’[ÈïÉ`rÞÚ~ëåÅÂÂ&Ç„|±AÒã$H	¦$:M¡ À¨Ñ‡c#)ŠŽd™2¦ÆOïÕ=6—ÔjFë‘¯rž1I~{/?oR¶´Ø¾'f$fM¨  Ä<U/»{ÿGQ‡W*O?9l¦Ð‡hŠtD%n'(5˜Øˆ´½Ñã·‡	æE¦KÂ—ÄN›‹oÃ‰&z“—ß\	EI¯Ôx'”¥ì=ã1«ÃÑ
+ªZþÜú:‘µ€  I4áJŒ®v©ý'Õ1Z—w!ÖŸœ6 
+	ó7FÍ±6|ŒÐ€LÙKs6çDæ)	×°<?#ªdè´c˜yP×ëì¬æí!)ì£#sªu9ÃŸ¦ºrÆ   |4±O¹=%ó¡+-»õjwGß•ˆC#bbãQ€»ã¡1t^L© áRƒ³’WkK]¸fpTÝè ™åÈÞ×åÂ‘’Õ
+\œ®ÈûØz×ø+”ÎÍj›÷—s Gãà  r4	Ò¹@-ðGAl¤¦2Fc3ô)¥–Ïd@‚Ø™„•Ûrƒ¶D­—ˆÕ· ~&+n­É	›%b|‰]hß;ŽÕcw(Yü%#çÑ]¬ˆá¤ªÏ€   %4à5‘nÇ8§·Ôú½t]ÚS#O–šÚÅáfŸ6DÉ@™qâŒ!§T$HøX õC£Mœ±|þµÕè5–7ä=½sŠÈXÖ½ö#œ¤ªäÀ  4©ïÔ³˜À—’x9f4´fJ&xÁÁ#¡ƒ£C"`¨ù"eE8X¡ñàP«¬„É(8nØ²¤ÆÞ™¢a«~G<7€ŽE¢¤·b#/àÏµ[d¦VQÒp  Û<¶æÛ)Ûsð[œ×+ß¾ö{Î§-%áÑ½ðŒn!n9³jCñ+!C—Â‚òäâSÁ	™`ý=Qá9™àŒ©Œ\!‘>2ºWöh))3»ZÞø”ƒ:<­º[]Ù·àN7ä5  4gkùÊt'ÞujeF§Îò~.à"™‘¡QqSCD>ÉR¡‚ïÄŒ8&¸ùÐi¥µ4\“†	Œv³tˆÓ*RÕI<Kf	â°)Ü¹¿ÿ6«	óÁYªØãð  34)°•_'´xnŒæw¿×)Q…	Í‡–ÐPY€‘“¥Œ“4\AÀ@ð\ÐaFÎaB2ËµÀb@á_æã¢yNñJRV'ipvÝàÍ|M}žc_Ø¼  I4ÃYº<Oæ±‹÷iÓÔæB\„AÈWÐ¨¹ÁHøDuÅés%0¥+|B±ÑyqYRÂG®‹ê)IôlÖ5A‡p5fD?¬m3j[¯ôê‡´ë¾ëQ™×M€  Q4
+býjx=ks“|»F®Y°rte`à˜ù`ÈÈÌ†ÆØ¼}ÀóA3bo,*d@ea1€°Ë	`h;\ÅåœÆv-‡¬úš£-ûpŸZE6Í9J²¤J   P4	ok¹^¨Iïîv*ä!WJÅÁ¨}0™±ƒaS"àˆÛ(40É°¸£ÆE’(aƒàùlÛ¬7Ü•O,+q+h; ¬µê]’ŽgìB¥€„­â“\˜£P  œ4tœâ½Êr\ë'æ×hQá‘˜`ÈÐÈÀT.>!Â#B·ëÑÌÐ{9+.(;|\f²ÌVá±:Å£¨781q%ÁKoÎJ'³ó€{Ï"_YÚÍ
+C'ÐlŒ  ‘4yNR¶À{9ªº„e6w¹@¼h&|àÀLø,ó¦æl‰Š–	Iš!<$(³ #nb'XÀI9(Æ9¹¾MùŒá
+3@ŽØ‡å¯“‰ß
+Ñš o¥Ï‹>  y4·/o	ëïôr¬ÎYöB7D	–‰¾â§7$vPÀÑ¨‘Kj2"“"Â!3cRÅÂÆ«›-"d3âbÕ1)d¥
+Ä€KBV6’ž÷³‘IÛÎÜ®`B   ˆ4»‹ÉlÓ÷‰MHHÙÞJâ„HÅÎ|0ƒ" Àù¼!1TbhDðÑ›ƒdÂBá’1i#±PµOG)ˆFÍ¸Àõ–î‚»HIÌI ¾á¯¿ë0+Ÿ’òû¹ÉÛ’ç õÀ  k4~ 1roVn`ØV¥”¬ŽBáAcAPè€H`uÌ
+Öž1,JLÈD^‘i¬ÔåKâ;sá²o+Õ_z˜ŒàÍ”Ô;b#’7 ‡B7¥ä÷nØœÏ|ŸÉ#²âaFÀ  /4ä½	Í.V¡‚ô.xv–e½$†åŒˆ	DhDlÚær‡K¼4˜ðˆ,FÚ£…k/d(‹©N'ê#ö°/!/7ù9Ïü’²!ÂÝËÑ®(  4ÏçãÙMe¥+Õp5ÞëÖÙ£±Q3ƒ`Šc¡"á!ü$H`PH@xÕL€ÕÂ¦N]¨>DôÌ€™A÷ð¤T˜*rÕ	îë!'˜JÔ¦G+Æ;g:tS›-€  4bÑlh÷OAìîñ-·ï¹ ˆ°€±`Ø‰a‘Ÿh°±ñº
+…BÄß2x"ph<È©7…L‚„ÜJ,1ÄçÇ$Q3Ÿ·èó7cI«’x=%si¼Û©ÚâÓmqóð  "4¡C`“ãYŸ©þøàd)|\DøØùcÑŠ< (©áq'‰Œ8""
+6&tã¢ÁÆ‘•0tb\o63AÆës1ÞÚKo~ŒKœ·æ”_%{“ÃN¤ÒP  ~41ö”Ög­õçp®¬úÊÏ&P}1àÀÙàH©@
+R¡!BB£fÄÄÄb•FiÉÌÈ[Ñ~#»dñi0Éøb@ü™¯·èØµNå¾g+IRÌ;N¼çÚ³ƒ¢ëf  x4	åd9ýœû»þÓ4$0ÅG„á¤aBCfApÁ Àê‹Ù’¶|lÝá0‰Y«G¢3CU¤ÙÊFDkŒÙ 8‡Æ®ŒGOf—”ôV¼­"ó²áî”Ä·lIbôØ0dä  ©<
+ê,pTñÝKÓnÚžú4ÉìÍ)û¸+$237;(6ŽŒT¸ œÉÐÙy	é	y	‰‘À@ü­°ñW ñË—„ÊÍG_ìæX#º@þ¢¿ÅníCl•2žx8RÈövéâóöR9“/§  64}ìÎT°¡©­&¾Äç4¬=(tL88TT<óò¤f©n‰”5=!~´Õx¨JÕÒYqáh>³JÆ“òGš†%èØÚF÷žNmÎ¬”×‚\ã­	ÍÙe(@  e4©Z¼·Tnò'7°ÿ›±U—¡Ò¡Ã ÊP@¼9A!!“vKGo–š¤ô-—“¨8I!~3PŒ‰bñ‹W]‰ù§ˆLÉÉX“ãèÝYÞg8»€;›§´ÐpùØ  -4çz7u“Ä¯ÛIèNå7%%!ÑÃä±ÐXun–“?'dFFä¥ÃÂóRC§Kœ·;]ñ:‘Ájçc@j)ïµ"shîÔÉ£|Q­ÏìÚ	Ìª³H@  4	]Á©á|xóf)XÏ£ N*$x@"H	
+ÆD°]°»„$4—“	¸:\&`LÌp.}«¤T˜^{>£IVÞë—!|éÍLë¹¿lVµKG©x75‡Ûb  A45µˆÎÑ¯Ù³§w8³÷"÷ZÐ@t¨d$t0y:â¡:')ÊÈR23|RX^€L¡ˆí³å•ŒhF©Ž&Á©×Ÿ—¯×EàJØåˆOe0=„B†ëÕ¹ºH©h  4âžô½¯NÇÎûf–%*jÒÃPñ·FBåD‚¢ƒ$èe ùBb®©,X©Ð ˜££*×WIAqÜ–^t¿òXq´W®(ÎIc™‰ÜÇúÓ|«Ë´D  4ñýŽ¬a_mù·üÿNõË‰L¼NtX€4*|avç$|Pò`™óí[44*tU’ÇIKUá¡‰TcQ¨ñ¿.Êm×³½lN/õ,"v>=Oš´Ìóó®   x4¬IfjÇv¬L~¤¡½|<…MŠº@
+ÃãêrØ…©k2£Då†.]5)( 3+V@`"#bŽùàÉÝäØõÓ‡¤¶Œ\ÏP1ÛüJIV’ú˜fZ¥É¶bS?¢@  Z4çgZ´‘¡”·ºE<óÚ±h:e9@«  \€.=îŒˆ4JpÐ¬ñ,E™™{–ïŸ§*ª^˜Õ1°Ç?3	~‚¯TˆsõhÿìKÙ·Sé¼†thc·…¥cbE   k4r)µ9:½ÏÒšØ—7lÐKKqÑ¡Á‚£ ±a±ß±bVÔÝ‹çË-KHÛ—ˆß9jÐœˆBä…Â«A‰]ŽƒŸ+åènp%ZcB•iÝ{<ˆ_ÚˆWŠ%Ê—  @4	ã=é[›ëÕËüÔç¯<¬sù€á7ÂÆÄÌ‚#&°&Ø“Bïˆ•
+ˆ> 	´tóÍÂåÎ6Ù1ñžðn*H¯%?lß æå!é»>·—©¾™R¥[€  ‘4Rò¤ÇKuRGª3åí)À´L&*(	‡DZÜÐ½-¢Çb´‡ä…j½OM
+^.p’"3+Bü•XßÔR$ž8-11;‹xÁ\
+Íwj) ô½ %]Ûü®˜¢C¦`  {4Ö»„¾sßÙÚË7?“ìýcPHÁáP°¨P@lr7‹Ž‹QÙ”1xdXvÝé™qÁ!b%ò¶\×”©†Å¸&%Ôëº¿Åö
+ë)àb­, Ü‘YZG}D  4T‘Ô¹çµÅé]4füÁØŒ0²ó’†	IÈËOÐ4˜—	ÔV¨+VZ+[V’ P9oæå´OXË7ôÊÊs^)ÍîC……=&Ão¸eêA2ñ…p   a4à!Åë=ZúÇøIØÎ‡ï0ƒÊ˜EL‹†ÅÄGZNZåÛ²RÔ%…ÌN75..fvù;ÓA5éÕÒ)EwFá•Wdäõçh~àŒCûÔ³‹Îú!WüëÔš†
+@  g4ì5N[;´³”¡¼ŽW©eNÃ‚ð°P‘á ˆ.4S"²'¥éjÊL‘X›ž¸,xFÜÀäÑuÒæ#ð…±Ùc!);6ºP,*ƒ9Ióì#/d=G[•l=þL   4«…‹õ%‹·;î[Â|}ÊjKx.Ø84hcï˜0H6PT™ÃC-M¾\ÐÙQ!@²h`xxa™’?‘ê.B	lä•‰ /¯4+Ã>?%ØÕ‹[IK3†•  M4ÈîõKyÚì–=¿B‘ëd%¡pÒpˆDàØ HwHJXš*1@ôP„Ø…¹³B‚¥¦ÈÝ3úÑ£ÑÔSÓ·„B}Ó½k°C»÷®Eºx3GÀOþKmíipyP  @4PÇZ·/éSè·"V¬Z'ÛÿÎ†ÏG„ÙÄ˜½!!ë2F‰Þ¹4`~ØZBáòãG&
+’$¤¿(2;Tñ‹–%¬ÿð=Î Í)œúÞÔ/í.Ï~ÜÜÚ&B  y<_M»måcIëÌÆ8œêÄï²‹Ò³âs’ÃQ1híÈËIF+ŽŒœ<*<%l\x~Ä|db†±xí±i‚¤’QŽW@w+ëà7nB	qð1_Ø®A‰Ïÿž¯+%@=ôøBkK)  94Öü—½ó'˜­6~ëYbœ .p`2<,tXvlIŠÈHÛ–,¼-xH°õ™˜@A¢"ã„ŒT<1˜IgÌÛr;LQ…7°y^Òí¯gÿÆN1(ÞOMcasð  L4Ÿâ[:u«Ñ­¼½Áwì'M|á"ÀÃ¡€áÓàèÌš¿X#$pNP´ œÉsáÁ	cGkÊ	ÊÛ§ì\B1ÈàbQ“‘
+?D|%í2“ˆÑr/jÕœû¶ºÍq²  –<©?â¥å‚²‹‘—T">Ä;‰8-G®ÊD¦¢6¶nvrPXØ¤˜Ù©Ó7ëŽ\ŒÈˆ]>lH•Á»¥Ã	È”ûJŒ/3^JßsÞ‰D¶ÞÌµœÃÙXŸìƒ“'Jl  $4ÿbœ$è7-áo2©«Ü¯
+‰	›4èÀê%®@.lÙ€˜ña1C-‘*@ÓÊÒ#ô’©Aˆ‡udù³k;QÔsP7[aÝU ‰y3…@  4éWK/m”¤+»ý:zÍ—ƒ‰:š<Ó-„ÅZ*€2ù“Î8 LyóDÊY.´Ô9—›ÛB©àOoíýno¿µ­o.ÉÐó¬$üá   R4¥ÍIkÿQðR¦Öªÿ¦ZÉŸž€úa±¡!ðÐð˜íÓ*%,FÜŒ~Ö¸ù™¢1AqBÂè¬~œór]j8¨%r5wCi˜÷bZ
+Ë[Ì;«ÒÒ%AùP€  G4™’”7{Èî:VÀÌÖ§®µ’Á4(	˜Â‚#™<tzôéùÁ+r³vèf‰†KÏ²°x\‹5k¡žÛ]G&Tl’­	y¤›2¡©f%èÌé5Fm°üÝ-¤   4
+{S<mJÛáA¨yO¾óy«pH xH<‹†IŽíqÜ€íQKâ5åÂDäÆiÆÄ,ØˆMÐ~p™Æ(	f32LVK™ˆŽr´»šš¿Ð`V)œ¦^[µês%*ëp   ë4µ‡ÖèÐ=§v9Á~ooL¶Db4ÀˆàaqQ‘Ž800p¸Ûa«Š™:.áa“ÄÆ	ž ƒc'©Ï÷¦À·|ÂQ	Ä1þrÏ—9«S –™ÍâL„ƒ#  4©ž“ µº÷{bí–fJœÌCÇ‡¸°´‘œ€µ`¡1Z9IÈ‘{3&¶%«Šß¢ö´h(µ
+‰S‘–³#ÿÐö¤£iZ«#÷õ&7±ó9ÌË¾€   Â4Ñ¿°ZO¡lYûG¬qÇHÂ|0"$$8"1 ¸£bÂÆXS¶&"0ETdÀ€‰±2ã„|ãæ†)]ñ‡¤Ou¤b¿³‰é-þ±){ƒ}áN%J£Ü   š4AR?»ßqW•Û)-Î)Xx:$K˜°ˆñ0ƒ%ÆË$(x>Ž "ÃÄÃ"ê•	3Ý¡ÕÆ!ý_~f•)	úþM_ÚJÏ’¼UŸ±Ð¥úA”%4›6   b4HjIqï;¹_VæØú„É™	‰¾	¾`XgÍ^óâ!æÄ¤ l"®ËNRšWJu¹3ælõ--¤¬…ÌÂ’àVå6ªÓÕj2è@×À   '4põ8â‰}-–ÖÙŸ³ad[˜0\2<HLXj
+…HmÂáŽŸBÁøq÷x0–A$š¬ºÜÍ¢Z·ÆCrR4®Ú‘ò¿õúæ„µ>Åä<GìÜÁŽ    4	žZ£ï%PH÷¶_Á2µ&0>6>8¾ŒT0X8P€l‹£ÙTtr¯"XÈ°ºBy¤øÔÑoùûqKV¯CÝE'$dìH_çY557{’g°º“D€    4¯œEü2}æm.ä)\Š²<p.hX@:5«@AÓ"uiØ
+fé;	d¯ãôjbjîòf^B† ”ýùêë]¿ƒä¥4Í­´ß”f,    4JÂFM®$Â÷‚‹w I˜€Ø‘m£¦†h`èËÔR§æM§z:ó¼š¢©›3M÷àŒäÖ»j1í¹¢QËõZ¥~¸[4òøKøšÜÜ     4V&„¸Áñ#ÅÛ„P8åµ¨Ž,x$2P	 `\a‚F|PÁCu™…,v±Í‘Û¨J#îð†[KY˜ä{7¦g¬P‹ÉÿR¥½rãÞØm0v™Ò2£m€á€    4	 ::T|ùqð‘NÚ4<pf(YÃÃ´eüµ=Cš³A~µ›ö §'Õ¬{F%®ÏIgûÅ)›¥)
+mç…*wð9Fã6)ë&"¢?t‡†E•„Ð     4—:0.2”|ð‘ásgÉ.kq"¡R¬Âj²\\ ×d»„‘R¢.ßÁh¾ÙÌYÆ§‰*µ&"T¨fb jn™¶k½Là[†ÐnN@I©ã-‰‘ q™—TTì¨    4)Lððvï4\ŠÄJ—(ªDO²,¥æÐ‘/ÃäùÿlÏs×Ù›ÀÄÖˆ÷-ù)^NÐ¨Ð~k/Zª„s•+RHÝæ•sN¨«ÈW $J ³î’B'@    4GŠ$Sì«[ˆ”y›köA{3a¿âXY#z‰m«œS!¥¨L##c‹Í~Ù–iÖb›%KM¦Zu§ÞY“ˆV´’ÃéÛ¦ƒ¬D-¼.ôÔ.hà   ¢4ŽøÀÎ´jÌÐFîxa"vXÜm8àÈ$Â3­!ØPâ	Q âÄŠ4$>á‚FnàãE
+/Ñ0âl+QÞhFðá=ˆ$3}   g4¾âRç,RàZ®ùf%pµÉ²:ôäß!2O=H©ã,V	,ø€©¦K²X4QhL™QàË†ŒŠŒM†Ê ÂÅÈ¥±UËˆvÅt˜ï6‹ùK¡REbÀ  X4‡r‰LT‘Ž^êÿ†¥°ÒÿäÑ!Vx‚!î j„éZeF/ŒÄ¥m›•»´`:'(#4Z1p‰6Rˆ ¥J©£=ª]ƒµcc2•T{–œl  !<%]$57{/)*/ª)\`¼ÊñÞÝ¿PÝÁy0ü‘¢znÜìÁ-Á˜˜à¬d'nL|v~ztH`zzTV/nB0ãÂ¬Œ‡0z±D	V®#cwrˆÄ¤Làôí“œ°Fdé"  <¦¿égtõ_–—öµ¼úËôÎ±)Ý9‹Cµ%¤ü9XT`X`ñðÔ¬ô3@<±†FÂ#B±iYÈ™Á±ˆÄ‹¤D0¯9¼!ü‡¦Á˜
+U£’Ñ«ÿ1E²sQ‰¢`  <b‹)Ô‚GúOCak?Ï{¶ÉeÊS2ó‚Ka£ÑËˆÈÅB6£AqXJ,	Iq˜ðzR,’„g¢c¹pÐV}Æ	žæCBu¤´½üØRñÐFjè¸ì„Ä_›0  Õ<¬ë.¾WÑØWð¢ù$¤ßa–ƒŽ6$­JÝ²ˆ›ŽåéÃ’’3bQc£7¢›1	ÀœÜèŒ¡ÉèÅ‰y›æ†è
+Î«[ SMˆH_¤µ€zÎVkô·D¢ÅYùgX\  œ<i¾×LxWßu2­°íCoë!¦tîèÈŒHËÄ¦Ç#½nXxÌì ðéð„œ¨nT|8%	„¤¯ÝŽ‹›˜!Ì3Â*9^è¡?féQ‰LÈ÷7h3§#r{™±„FýC³Hàƒà  »<h¿É¿ø”Tì§Ã}OÊû×ÛÚÆKk–XŽ‡fÄ)øèIŽHH†ÍMŒG…+°¤Tô”ž†TÒŒ¥Äbº±k÷.C}NÎÊÂ˜¡3Jä¯ GKÃ3a°0  §4¯?S›2_\¿#ë0†jÛœ¤m*®GÂQ1Ñ¢þfÔ …ÁIºáQ9˜ÁAú*–äá2o*+úTÑ0põ›!9‰\ºT©%#[3¼µN¯€Í”›®Ì¾  Í4MíVJÝú3½Û·-.¥i§´&lh ŒÇ…G*|Npìü¥à…©‰Ù	r¡I¨˜lœnèè‰8d¡ÓÄEƒãa~÷©#ªär]|í%Ø‘ÑTÓc¤®ãÛ¦Á3"¹•5  —4	X•÷+úEdv5vçYÌðèãRGÁ1cá¡ÐPÈÿ
+K—»#,&,)%.1[x4&¥)0/pèTàu¥c?í	3lÆR²õ,{á¼%=R¬¯^¶+€1MâÒ¦áo€  4çË\æ÷‰Q÷_îä·â4@Ø°Ù±Q1¸`\°³ë",6h‰1ãâ#Ëˆ´2Ød¹¤ó¸He¸Ol–¾KŸ&ä+­ØÄN´³þW²ûòíe1$Ô  $4§ýêãRábL©M}«¹§ˆ¸™ÃCá‘WÎ‡†,U¡ ŠWš
+	xÑÐÀ\ ºâS†y ‚£%T–:P¨ÔŽ³›2žÐÔ{zT=£vŒ†¿ŠeêbçÍ&  Ç4QŒíN/´žtoÞ½~KŒi$¥Ñèh 
+ƒCã¯(dôpÀ´¼Ý˜€œŒ0yø"l6*--^DZ,VtÜ•˜Êu_Úžš­ÇÐ­«7&¢sÖ¾˜µÅ¹jC˜‰ŽM"Î@  Ž4ŸšË™=¤+d5=ÕÙÍëžÝ"@±’@À|.$±‰¹{³§ož²::b<bH)d”˜!#h½¢´£’ÂTkŠ‰Sˆñ+Bìè(ôí‰NdpÚ ´P/2<  4Ôæ¤ïWÀ•Û^3R¤†uÙÂ2«aÓ£’Oùq'IºtdX¡Qá'ºxx\‘FÍ‡4˜ƒ,»é‰Sýâ:ï^Î<¾‘±1>j×çlÅ´ùù³Ñâ   44ïÊ¾UÕ);4¼ÈÌ÷œS[¸HÚ°@$<$x°Ãk	Ž¶pˆ©áãd‹
+
+¢&¹` ò¢ç˜ŠSÑCÅª[Ö5æà‡.Çz’­{JR^èw/ÊÚi   Z4¥VïÔyê+Ì]—Ÿ“5‚:F‚©ÄÀØL":ƒ4—„ËˆKMV™”=\#48:dd°¥©³‡+Œ!õVy# zÕ«sï?üS‹C|¯;)ñª,Ð•L—  \4÷9%íèfþ—ÿ·£“u(z|&TŠ¬jšä”³¢WglÌFÊ¯]†(ÈRz=)~hÇ"Ãá·ƒfrÊÐc›“wó~1fB¤§¬IQµ+"?ƒƒ\TŠ  q4îŒ•‰-­è!KÊ³>ýk¹¢ŽD×‚a‘ d,\s7mÌˆ‘¤™ 3“Ø¦2(+|ÌÅ
+™PÄ48š/èÎù/ÐÌ
+ßrrÄj§±-Y’ùË4‚   S4qJÆÁz<UâåúU(“œÜ’Ý<ÅÂ¡¡à€íˆØ–¾'¤+5$ O*<)'¨!tøFÉGìfjX™+Ÿµîî¾CÝ}~wçŸÒ»ÇSÖ×š%B‹@  4É:ú•9¬¬ÑÓ7~,w`ð«ñÒC¡°àÄƒD…Û&(X,PLY@èðHYðéQC]
+¯°ºƒ7 ‹2ÃYÎuýÁ›™„«í-j¥+—´f-*¯²â`¦À  H4¯ˆ½Ïõ•ÏÏp—·¼žÇ¶ƒÚq |0ó3“ô]…
+ˆÎŠ^ˆÑ_
+ÙYÛ1%¦ dˆÀˆc´ÑnÕP¸­7J_A8ÿÁK’‘|v·#^Z¶Ái¢žJÓbÕ  49Ž	kD²ë
+RÙùˆ­Õ ,:8p,<6dd‡ˆ‹‰$"Ju°dpÑ&ËƒÞ&|Mù±ó,ÖÈHFüKÎîò9½²3ØÀåZ
+‡?h^Q/  •4
+HP³n•{ý9%ðÈœ¦S7Ï\¨:…PLw"FÆ…Ä«ËÄÏN‡ïÉ\»5!/#L‚ b–JòÁöâô*ÈåUÄÚ›»ÍÙ»=IÔv&ÔÅFj   %4¥´,ÎWÍ!9Ýöîì,±Ó"CÁGƒÁžLøùÃdF„Ë	Š:"tTuÐd@P²äÅ¢Í2¼˜ÎçòºT'ÙêÕ>‘ŽRb1zGå©f1ÏàÕbÅåŒÇŠ   4Ö­Œø¡ö’kÄ‡º¡îíÑŽŠ’8t°D\Ð°ÂN.,PÁÁÔD2(a XH\’Œƒ	°mÉŸÇÂ•:)yn(ÙšÄÍìhëJµª›x¼p•ÂÊ  •4yRµÏºSŠÓ7/±^âõ]N68*ãB#C¯22|Nô”ÕÓ“1úÒ	à‘P¸õ™·gï
+¢°,¾Š‹tP¹Úó4$±„~©ÈŒKñIŸ)¬ç1I”w   h4–¯cà¶»ÜÂ%îÔ±Ý¹c›UŒ ¡ \LÞ•¥+'P fíé	H¡‰áaWMÉO—ªVB`3õn'F±ðÎpŸƒãüR^Fbçbò_Ç5nUÄ@  4‰Ô•¿F¾³3«÷=ßå‡Œ„ÂÁq‘± ð6:§ÄedêKÅèÏˆÚ$&©=Eb(\6tÉ²4Gc#»bø¤á3~!ƒ°OÙ}8‚>ÄG«•=å€´ÕtÈ  )41WIjÚÈÎU•Äþ„´};Á…Ä‡A@‚#¹~ØÈ±²R·Gí^[š”œ°bbÁøÝ/©ýîNžÿ	£q>«Ìc%kÙìnÌèã–mn1áaYeÂ   …4/ÿÍ«ÿÊàz)ºÐ‡ù}Ž© 	”ŒŒp°€èîIÍ
+NØ•™‘f‡Í†¤¥‡­TËD‹.]#ôZ7³?‹2Â“ñ3yNBîÅ3’ÜrVÞ#ÖR³2Äk8  4·Íœ^±W^ä°ús½ÅJ‰\>xØˆ.*@*1DF‚Bm‰ˆxLD(f:XR"Hˆ™pâh¨2•Ü£þHýsŠ“whhj%•;6¶¥vÂö·—ÎDà  4æí\¬ã_ª”hû'Æ¨ZÇ§I…ŒEtùñ¡%ÅÂ*¨d<T<xLÛ2¡pº÷O±pèÜé‘¼<v^Þv-HÚ¡½	ŸgóIj²C^rÄÉð2ø  M4LÅ½å¨ïVÅŠOq’“rh-
+<#Ã¥''%!dLd\H@Zü•Ù1	Èõq³„¯D„Ì$Tülö°åu	ò|êÄŒ~™(îä£\”˜ÊøS—ðç€  4ÿÓ8Š­¶³c½ÉSÙäe†Å‹ˆÂæGF":xóâGÜœ@X*L&..ÈiCÆÅDŒ1U“C+€ÐV“¥ç)…þÈ•YÝìÈWÒBgs³4~øþîJxã3  4‰îýJ:ýý­h{s^üòY¾Ž”.*	01qÒ"§T¨Èéòe‰'Þ22¥ãÃÍŸ&’qQ–úp'‰EiØ†Vây´Ôõ—ç‘«’’vÒ³-Ü`  4’ï­d÷À…¬èävÏFr}LÎ2$2xp™á…I8*:Õ±³ÅŽ”RxmàÊ‰´u¬¾H’HŠGq³ Š£<K×ë!Y:è»Ë²•6ÒØ¶XÐ™I
+@  <~jÿ‡Ï>Ý¾p³îKÞ¿ãoÐÚ‰ŠbQ0€v„ÎÊ//‘¿<Q=9LŠ]Y.‘V)Ff2K×‘íK]‚òñÃöíIf©-uZŒ…›à®Ø•cÌ.  4¥—Ú^÷ÿçúc#ŸÈÕ#˜¬±ð‰aø¨¡qñŽ…•TQà‘ÃÁ¤Æƒbeƒ.
+‰°R˜‹îýÖpÅ˜£’½@k:@¥?îb#F·W¬æNÄ¥Å¶•Hè   4!Ý-BÒ¹ÓúJë+³Þ.A±¡ÑPðàX±ÁÉ‰Ó’.þN€FôÁÓ!r[Òæ4å©)ž vüb»–%‹G	ÉC”A³‹øjwŠ×$½ÚÄ:aÖ[Ðr   4	S«~Ñ}æ«`Í¬çg¯Løà°³‘0D¨"@c"íƒ&”|yñc'
+Š™`Ñ°L!v¬
+G×Gý“	}rÜ½8OÞ*X½à´¿šá;ú ’ßËô¬`  4HïC œˆ·µ¯ò/Ï‚]ªÕódÆÈƒ‚£(&yIa ³Bë„C+ÆZ¤2 ‘&Þ\kî±ûËœ»W`¥HµÜmKûôç…ýÚÆµ%þf¤¶)f€  84©c+åcyù
+V†qsË™›Qñ±0D`TX`À
+ŽÁ‹5O…é:(&Hltä|Ê^HÎ¨”ÉQ¢lëª.…"äŸ¿Ô“­/ÿóßÈIa3V°NÅœdÊ™§  B4”õè¯KØ“À¾T0©V™#¯LŠ‚…Ç+~TíÃ—&¬$DÉ‹ÖËŒÈ”$3''jú…’Ñ™˜+e6CÖ¹nÏ7bÍJz·Ý
+8j9Óâõç„À  ‡4Dö£ô3MÊÖ;¥5°km¼ùAb£a0¸(0NŽìÁ)ˆ½²qHÙRÉ»RFâÔBq
+z0‘I…Y@Âº3*±*°§£W§{«3‘¯+3Çs¥RG7ÍÉ¡Û   :4û;<KÛÅ{õ©TÚ2â_Ödàt>àà@H4;¶*kX‘›)”(.@Vh”t\Õƒ÷£÷”ê‘R>×¨MDT¼7€Sj¶''1³)ÜÍÉ>ü¯Ç|tŒ¥Vá€  H4	É`äS‚S[©J­Šßþ_f
+Žˆba³  îŸ/)&~PBLDÐí¢±QI¡	âi;Eˆ–‘ŒrÜˆ„Ê’ R‰98‚KI}«A-;“±˜­Û¦?ô¤ÚÞ @   ü4¡‰O¸Þg«¸¯ÑzkI~ÄÉ„ÅGÉŽ“Ók
+"t0dÀˆ«ó¢AgO84ÈhE¹“Þ²á
+ëWÌjåŸ„½«bvG	x«ä¸[‰Ó ïæ@  	4÷›YTûkø{3ÿu)ï¡”,tP|\¨ðh¸ÂDN”tñ‘£b#D9Œ6SAPTƒ4ŠšÖÑ×qfÌÆDºöØ®U$ý½‰Qï—zSVR`  ~4Ìn³^“vù”òÜÍKŸé	“¦0¨¨6‡ÇFV@^Ü¤Õ‰Óa9!ÕÙSakaÊ\DC1JDå(ŽgÂ’àÄ_îanÚ”œ¦+`%	`ô¤äÈîT³º®À  24‰e­I
+u¼ÝáYºÚè)A{„FF €aÑA†yÐ˜‰ãFM…Œ0\è©#b¯B%Ó•66¿°-ù*Gu˜þK¬ç«ÔÌZK°BÎDä&¨ÐØüÎ».¸  Q4Î‹ë;GÚÛ³µû~ïïQ“A¢à˜XtMJ-|&^R`~ÑœØJ”TèXÙ›ƒER¥Ýq¼)÷Â~Åÿ¹rœ·ÁŸBt,q!Çv??-v   F4¹'µˆª¼ç~íN(u¦^622	‚ÀÉAÌ±´/fœDHRü å°"H!h*($¢	ÕT¤òõ Ò-	oØ°R´ŸñYŽäºˆK{äý®$lÎ~O)pFmè  -4nÿ;ÞÎ{|‚Ô†«oJø–ÆåEKŠ‡GVFxÅ£Óv
+K
+¯!&;9(~vINbp·IJÄÃo_Ù¬xZÅnZ_Æ:%%nBüb»h!Y€ÔË…Ië   â4;Š»­{÷âxï[<#¶Û
+ˆ¶dL8xL"2„Bä„¾ñÇEÌŸ@°la @¸ƒÍ	¨Âd\šyÐÂ8Äsi)Îž«fg"7uò¶¼çƒR‰lâÀ  ¯<ì6ä¸ÛqÌ¯•-Ö§žr¤÷ð‚Œ˜äÄÜ€øRT-1?4¡ôtr^ pv–øtðtblnN`hÔ±Ús¼Õ ¿#}îÂžÕšF6zìúSÏsiÊ$Õ§ÇTÞfíV‚À   ß4#ô¾¢^¹)²U}ûM=¨õBCB/›2XcÁ%DLTLùcŽ	¥p"4ØY”eFM.(¹‹D+K¡c×"9‹Ö±#ÈÅš}cï}rý&êËQ%â  >4êŒþ±ÿÅ+å­ï.ÒÛg1L˜Àáq` X<,?cd4çÛ5'zdõ@¬±©Â‘¡
+‡fÂÖÛÍÖxh0Ä€ø1´I@G+¸Ø”ŠZ¿nìç±Û¹[½ÓÑé2¼‹k    ý4Ûÿq•À´¦%¶îgKz‰’g†Ç„Ôf6N06LéÓ‡	iÁÀª¡²á ‚(úÃv	zwByóý[šÆòJZÜþÑlèå†³Ú9*×d   4¨+Sý¸’©…;=ÍúþY9°0© ëB£ šƒ:> &`a¢ƒ!S‚HÜ>d,0ò1ÀÑ‚(°pnKWVUèïŸZÈŒücð½É¥w÷îw+Ý‚2ô„N   4”ìJ—Xû#ÿ¾Ù©¬=·8ðPÐ©ðLP PbG‚†Š$XÐ\éAFÇCd
+
+›°hã”P˜¦¡€/(úI^”Òwl…ú·J¼jcYª-ÊzíÌžZWMà  4ÚÎgžíÑçL*Ôºs?îŽ
+—‰ˆÈ: À™ÁäbcO: èA A0}Üðã5	&lÄØfÈSÄ§Ev—‘§äPÆó<Sÿ·(ípÄÌDÙø  ?4T
+[ßÛõ¨uGß'ùRÞ»QlðlhTàè2<DøêK”ß(#-pNÕÙ³25¢U#¦)dGlÛ+$UV7èTjÙ1Žâöƒ:Ìù¼½98Î…pŒä+\sèüË$   :4ßÚ†Õô’±#ƒÖlU;cd¶º(8ÅEBã4htó€1á2¤	
+‚oŽ4ñó`Ââf‘6DbÖŠ{­Áy¬¨'À”G®iLÌÔ #+ü”zd'‘¦eIÄ    ð4“¢;ØÖnˆm§wqÊwö·.4Uq¡Â‚c$‹ŒT(¬DÁFJ…*"ia²!·Œª&œlm»Æ¨ÜÙ¶ —¯SÊs+¿!#Ž23•¥!…kU‚[®Œ¤"%   A4ôÌö‘:–ÏW•îÇøf7ƒxÍ„ƒâCA`\Hw¤‰çIÄ$èF(D%ŽšÉÄEƒB¥$ÒH	µ@T:ME6¯·ÒK³%±ùúƒ%Ž»–úi?âÁ@Qžl8.p  4Ùå>¯-H…Íù5NVù¾Z@x80`4„Ã&$…®8d<@¼ph$»pÁ!V šO. ¬ÔÁñî¸J!X)zµo,Û§[Ÿ·êYØˆZÊ'fqf…   _4s¼ÄÿÄ¹PÎõKÔ6#Dä\‰È DjÑ+jNÜLÀjKZ/P›ÆŠK«ªüíUBá—õñŽ)Þ„)5n?x† ^H7Ì_ ‡lD,¢rcnZ>  4ô5[.ÎKÔ¶V'Í"?~´™WB'†‡ÆCc,° `©òBeË 82db²@›À²³ÅÊË¤34‚,Rz~D5‰ØnÑÊ¼Ã„uJ´žØIîÔ”Í: l   ´,wu•GÊ"‚!ÙqYyÁ’@ôÊÂJ,qAbŒN0ìÑ¥ƒ©Äõ²aì5¸›#Ð°ÅVÔ~•Þˆû/g"Õ÷«Y¯N¯æhá±9\÷
+    ³4gW|¹µÈl½58eJ7‰(&"..6§G&m”"cÞ$Äh\ÐH”á„V'Q¦ÌŒ/‰à…FZ+¼^¡ÿh×Ðs±[ü^Ë.â•’Ñ§e$•‡€   ä4ÝÙMâ%—³ùlµzÞÇ16‡Ä‹‰‚ãV,tMñsêdL»!bbà‘˜Uãb†ƒŠo(”‚³9M1©o†7•÷b^ð9Ø”R¨K½½¯#:1õR(‹€   ù4/ÿÔôÂÝåèwÓÞô”É±àãFƒ&Â!áQ„Í`*qñ²Bf‚©¤	¹ÎXÓØÓ’éŒnÁvQb¡70±-)¬÷xÁ+Å%òÔ„øJ¼àÄÚ7"   Ÿ4)WW$|T¯º—«§½³š¹4HUöŽ†ˆ>1óF¹ÃªT"Ô@E`ŠÑ‚®ÚhÒ'g–™„ƒß©Útçªð©m)Ó•Ì¥RúP¨ð„«Ë    ò4^ß¼ÕÌÇ:Â~—îžþÖWÓæÉÂA“¡@Èí„
+ªÍ3.2pdü•ò¹iyŠËò"G‰ß.½S:®ÅA7õW&œ+²R~QþÜsëvj¼Vœtgué‡IH!BÀ   ÿ4±ï–ù'wf®j5ÅvSrÑÒÁ'Æ@¢0HpTâµ…ÄÊÄŠIN—±H+*'2HFZ­Á¡úÅ÷¦š7e‚4,
+în¤ÖÝC4ªé‚ÐÀFsP‡¼#ñÓ.šaÐ  #4;ûKuõb§Ô<¡È­$™!á ÊÁas`™á@èéÚ´ldFØ¤å¡º"Òå1™Z&D&LÒ·ìøh…!c·ê›Ð‰Ûéà 3_8æ1›49*ØK‰Êç4`   õ4ùëW¬àÿr>eåiOŠÖe‰£'ÏBBaÛ1p`Å¹¡›%çfhÐDd«Æn¬	ÕV(!kZh0z\$5`*”“àÕ¬áŒÉÙ»ZC»_ÑîVdrãf+v  4S—º‹xì=GWê×Áýb|ãAÒ£À‘ñƒà ÏŸ:pp‰ò"Ï4:&xj":˜&œEg"‹·­j `N”žÖûê;C™;—r©7dü•Ñr)>v(ï€   Ú4þ_Dœ¹¯‚»âíœkóÒ¦K2@*x:3.º0‘‘¢À‰ÈëŒ’¬4:a!sAFeÈ¯,`g·´k>¤Ç;âæ²6¬IbÌ­…¨Ü ý.»’+,<{À   À43”††3hCê˜[Õ$
+ÖÉr„D…„û, ÈlÉƒ""ï\&$%>ÑõdSÈ@xcÙ	1²øÆ#^ÔBwê:Ó¹g|®TãâñD‘•3¢   ü4}T1»}ï%CÚ\ê­<±ÚXð°ðAø`D`ðí‰“˜'5$hP#[FVZ’ñz‘iIšÔŽˆÆ»:_ô˜g9”Ûràÿ@BÐ[“Wt‰c5-ckIUÜ€ç}#5(>   ª4Óñ
+B?õ§WøJfzzaƒŒ:&XgD‹ª*B4Y×F…‘¼$*iñ#ggÜ5uòÓÏ†¼=Ÿ7Œk¤'CË:éÒ–¶mÒ{1ÍÎ•Ü¸   Õ4ÊŽ„({×6*à¬[Ð÷¤¥Ø
+”h…Œ„‡Hü”Í1	CËrõ¢ÇI˜»¼VÕûã„ôIÐR**VJMøœædå¨OgC+pR\I¡%K:S…ÎM¥,	   84–¼;{mij_È—ès¾ÄûÀEhh*
+ŠaáÉØ˜	‰Ù‘<)/n7t1ô0=',xBD`+&•$ê¤~‹d£é—v<·È´Èqªˆ¦’¡‡M>*9eI[Tžo x.   ä4wžY$|z°#ßBëf**T,1AfâcÄŠ"RLdèi!t£nšàAa—fòÖ‚þ-lN¥âÚÈÏwùšq)*d-ÑÂ†69ñRp÷    œ4‘«æ&VK­tÀ_z¦9n¢¢â§&lTc‚¯,ùc!	<&Ø]ùÇ•‘$ÐŠäR(440þ‘ñ”Ÿˆó-¡ËÂwókZk¹J5ÉK]Š    4½¢Ïm²Ö´×ƒ^î÷©d˜H©sF‚&yaI‰/.à@‰tÊ‡`8Ÿ$Äd³ú=	pE’¶'i•’±©‰Í9±ÍyJF»¡HÖ³+v(h   â<É6ôó›7<°(å›Q‡rªã™a¸¸„Np+ŽBøÕãs‚U§å*wÂ(ôhnñX~ö^¸€(1öX{j¸{šyv{&Òõ#Ñ"õ‚oºU¢Ûh¦ÙÌ‹Ãš½ˆPÌX   U4"wÅü/.!úÚÈôYò@ûÁÒƒ@’!Ñ&44|±²Œ
+š†h[IšKÁôˆ)Æ¥†oš –ªà¯äÌ¾‚ÑÌYÂ\ïCýÇä%Hÿ—å%¿²   <æµ.ÖàO™†­l)Š¹¶uGð)QñÁ‘0Ýé  œved…&
+lÊÒ››,­KB›2®/.îTñ¯æº´å™I\áÜ“o¿Uþf3NÄ!Õk¾ã;Å5Pr±yX¸@    <?Ø® !èŠ©•bñ=ºì‹SV(ŸˆÏQÅç+‡812v!+c&bÝbKù¡[—JÄöˆrÒVª6°ß0…Úàœµ‹ [ 'üÌ!ÄK8Í ÍÞçëÅªÀÑ‘¾¡Ã     4Ö*qb„ª
+²B’^a(GôÅ
+«
+*8&2ÈÇš. ¤ú)$‹«»‰‘5ÿ XöªÙÊù©ºÚLÄ#ŸÐàS æÞØâoséRæ†	Ûˆ­“¬ )(x    4xÁ§‰¨˜hJYó©­r%å>0xA8he*h;¬y0ºe%|Ÿ-¥ÕkÐÔe[ÿi²âg×ñ¯@rÀS'ˆËbT_2§÷ä°ƒ¥Ü’pbHÄ_    4ªlXƒ-Ò(É“k1±„W$&ˆø€‰°¡·Xä$º.šTÃÚÂÔLôÚœHÌ ˜ïÒsèõ1 BG:r	vòf3+JFlb³R&²’Qx™EËŸºÆ€    4/&IEÿ%"óñTz¸¹ N½Iç¨F2àÝP&3ÁLdÄ/°ßK7òºËG7fTvdBEÃ£$ÿ8&N}cgF!·t~zA¶'1Îú†L‡$69#kç    _<ð2$ÎÞ¤ÚJmªÄÿ™"ªÒ²ºõ'Ì¤M)Rl>Ëèøe2	—Œ»"ítdY´HVŒÇQ•ÁfO ŸJ3(˜E–©LÈõŠ·|„2Ñh(>Y­   4ýÆ²Ûr÷ô
+{q°jE”Y#èóíy,m™¦Tâ¦d™Ãç	šJé *¬p€¨XØ¸€²’ƒyjgÜqë(Ò–Êo­œDi
+é5 CƒvÓn0;ZçM@  ÷<öÒ;?d’~×uzOwÌ(¨ü£E(©))òAØß‘Lim$Ò)Ù¨ÔÆVz1Ë¥ãÉ8¢Ve=ª˜]PÇ$ 6”0¯°±0Ñß}N«2žœ¦'Ù8â`•öÎ—À  ?4¸ú
+hÚÔ¬r¼ÔcÞÌkºiŠ"&Á§F£¥(EpàüÍ‹òqA(ˆ$^P|2-*>5‘ž§4pôc­¢(P¦=šá­”9@{‰HOb2:Å{%;¯bdhx  14ªJÍIÈÉKënFg #Cø—r­„ÀÈà\,6=LÏJNP\ŠYœš™H!ƒ¢×"òW.œ²<æÔZí öâµ3¿­»ØŽBùR‘ÌåYxªÉ,¦…@  o4+ü´µ¬ÙëZŸ4â»JÊü ³Ð¨€@LhÈu‘ËU’-.!&&dBì­Ñë:qó¥.:7gFªåÔ'ð¥Ãu~À{œ§µÒR•Ýzßû\peÁ”®$h  T4à×²73©K‚òÝw~‡µ7)v†OGVV±À­[çdÄ‡)æ'DâÂv×•¸²A¹`Þ‘(;dZTœüÄ@bö£÷¹§9ïôhÐ£|ˆFš%¦Ñäƒ    é4å¯èu´î‹Yöž˜	ñCŽ“‰…C ©¡ê¤-3TJÆ¸ÌqZô³´£Å·$)G-ú·f¢¬c³ÅlJ¦KÉúz7‚žÖ½oþMÒÜËýqé®œ‰`   ¾4Ï äéËÏIóò&º°lˆ¦  6h`H$&ÂbžD‰p“eO>d8.,u¡à›$BnùNkñ vÚjÄ+‚ÊKa!€•©®ðñÛŽËÙ%°Ý8Ù   Ü4ÈPz­üùÙ™\!®at£ž>‰À€æÆ’ä–­*: 0a\`D1+xÍHÁa“é¦R1"v«
+7cXÜ¹O®wµÿrö6ÿCÚ1°RlÁ«&]°   ÷40¥ ­_jKP¶/­j’ÑÃ„Ã¶<¨.àh,=èŠÄÌÐw:rŽlqQ3aS4‚ƒ*zO›¨™Vþ/AúÅ±¼òFî*Ç6×úÀ^ÊÌsæÀÇí   Q4³åïÿtš?^f•ÑË„×ŸFXU°àd˜MÑÊ[—”« *fÐ´V¶‘¡icC!qúƒ#CÄídfë˜X—_²ø[ŸÈÐµ(„åž7ÄôÐßÕ“83r¬
+€  .4JçPnjC$ÎRï²œ¹$€’SŒK‚+ž³Óâì‡Þ62D$â‚x@Ûaa ²QWÖ`kqt)¼›zzk­d¦´±èì¬¥Yð'“ÿ9‡ÅÔjïÈ   P4/nT—ÊS2³Ô¾à¶›l*ó3âÂdÉB1´dØ@BDH$LÁñQB!çFÂ'ÇÒ*"®c JðW^ˆoFFºÔ6›‹V+~!=oí‡:+tÿŒIcòà  „4ã3LÛ0ßvëJfVÆò›Í†^Œ‡†‡ÇDA±û›2ªš>9-vXn FD5PN)Oª.4|@Œ¤®c² í’çðž¦/ˆÔG±Yh´Ö"Y­ÇAŸ®86œ
+*   ù4/éY{•ÈçVÿ¼µ2Â¸Œ2F8<µá¨è¨Ð×X(ø“À££†\‰6xÂ²AçÍ¾|Œ±ŽWt{Tºbzïb˜Ïk·R¯bõÚ6«ÉŸïmðcZ  P4õbKº‚”%3%¤b¸-.W…&ÏÈ@™`X5¯ÂTnN˜œ¿=%H#*8)%+Ódzv½™ÓNƒíqŸ}(V±øäÕ=¥¯^î„¿3Õ¨šï‹E  P4gN[í¦¼•º!£²=´LpT†HÄ &=…åçfÌä%ŽFæk—’ ÕzJfR€^£Ÿ¡½Vàèa!Üƒ›Íu£¼Rˆ)„gQo®ÍàbŸe	©¦Ô€   Ù4	Kü¨†Z]åz»çW6jé©XÒ¢Ã……DÏ…‰ðAC¡e-Š°*ø¨É)Á°˜¢÷…^ž0TÙ(êåøšÇÙdÒDº‹u¯ó½iî×'ÅŠ×¹Ê¥;¦çFR±Ã   Ö4Q+GBv³Zz‚‚ýY9åš¬M 		<Ÿ"M`ÂÁ¥YŸ*$,x€Dd¨ë¡Â¸”é÷Ìª¬Ø!UšY±ˆJ¦b·¬ógjŸÂuôz–üËcÿ‹’#   ô4j~ïÅz×í¸;hGü~z" 00|À\x…ÁI;‚•ÆÍ.Íˆß*ÝpdêZ•^±Æ¨×¾j¦¶yçänœçc4¬If=O”…ùDfX‚á0   ó4ŒÖZ#@„Îhè„•ì“À.ÀLLD@$¾LÐ@‹H¥úÇ¦Â4rUtŒÌ‰KJJš=dÌÄð§™’-ÆfY0FMêßd;šÀ!°^Ž“ÞëðÍýmˆ\áÂ³rX   Ç4!üú§5A]ñÒ·r}¦»1VÅ‚B&Ž€ØÉË4BBÅDSš60D$ºE‚Ë¨ ÆMÌ½ãaýßP¯™„¦©UÖÊog°l~ã»ÕJ[$â€  4­X	koa‰Í]5k/8°P1Ø‹‘L‡I€õIÈ‰Hˆ²+*¼&QZp@'Y''aHäÕ’´¦S˜çCÕ+ÊIQ½!z®#V«c{^’zYa’’/   â4«½­Ðræ¢Ûˆ÷óè®2€du¡ ™ ˆL@b!BAP‘Ìž*¸ HØUøHAÂ…i]rLmØ’
+eI<bR~-f±¡jõ¢²YßßÂy;CŸŠ¯0P   ¢4!•¶Dc³#còRÉ³ÌšXPP¨ºÃ™`ùå68ªB‚	JpDÑ‚AB>À”“ƒ#Ú¢ö˜èåZùÖBVˆŽf¦êq¢²8´C"¼¸€   µ4—}fjlÇ%ovS>Ô ¼lâ!ÁôÂ&‰q¡RNx,Iq’‰*(ðè²Ç’œpñq{,·¬
+W¬;¦/ãn×˜©%o¯“ÏE*v¡iOLÕ    ï4Ñ;•>‘À‡Õ(éëöfðˆœ:8Á£¡P¡™á3ác¥Œ4¬:y)£…Æ”ˆ·UñŒÒrž"ìA‰á{1*671N9WŠÒ¨V–%+½-Ž<°  	4“­¾>ÓŠY%\;Ù<RËx©`ð±ð€ødðøl}Å(¦hJ?p)-JŠÔùX@Œ‰„Ù3C%ÝÜLµF7«èÀÈ!H)R+J#%òñØ~¡!X¦¤º nÉA~°å@   ·4õ…Í)àØ†u¦)OVtM(‚ó#$ŽƒKž801â¯	:*¸ÐñáŽŸ:4èÂÒˆ#>Ú);4&ÊÍèl­®¤ñŸÒž—«ÔÞ¼Ïz·[õ„2u‘PaR€   Ù4Ìõ?Fíìþ2Xí+$»(4m	ð@ÚPÑÁ°,¨ÃhN‰
+„ˆ6:2A˜é@˜ÓÀUªÅäÅI,ÆIZÀ÷fØ¥-9µŠ¶x‘Èíó<e3›DÂøze_|¸   â4“¢#.œ¡°…õ)uY1¿dÏ‚‡€‘ÀÀÐÅGƒåŽ:88tM IÐda)V‚e‘e‹íŒ¾|(YT
+B½I*›ËMô%;Ã®CãAÿ~Ze4X   è4¢7DµKæ^–§=øí#7†‚…‡C£ ‰ÀêÛŒÍÐ´*bHÏ—(.–2\!+yàbå:J.f²‰H•Þ…)¹ÉŒ§éoÅI˜V~ž•ŒEêÖ_óRÂëŽ   Ê4+5µü3¿ÝÝ_‹v=2ƒ!D¦ÆL‚%NÄ\``©ñRbÅ†$<e˜ˆX,jÐ"N\‘÷O—Q¦ùÉÀ[…‹á;bÁ™	Î$hà'z;›—³ƒ?ýax @ˆ   È4. r®ZùW›~jð½ŠkqMðÀºH$h|ht$?‡ÌŒ”¾”¿%tÙp¥òêò²dVI„
+¼³PÉÂ;°ƒiÄo\	Ålè+/ào»s©bäu#Â‚Ä’A    Š4c<ËÈË	äô–ëzöžè˜±ˆ¨ê¡ÃÁFF8R(<@£ÓbÂ‡Å	5 "Œ˜ãÒÇ†^ÊQÙ„F¾__®õaiÝ‚|ûHc!{väd:±ç¢— +cÕh   }4Ò@­®ÀÆ_'w4Ð§Ç—.L<‰³ƒ
+‰&Qƒ‚gzPdÛ¥EV'0t«ó³$üÔÍêÖ¥VµoÚ[”ãÉ´§;å#|QÉ‡~aIxH¢à   {4÷Æø©÷omáŒ+z•Ôª`˜áÓíÇÅa’¢§RP0 ý‚ˆ„Þ,& ¶0šMIôfªG½©«~åŒ¿½Czwöó»²Žï¶‘sÉ—\E`   u4ÖxG">TÚ†Èaøµ&9Ž©tyRæ‡š²åØYÑ÷Ó•q²dÃÐ¢*PÜI”$”eÕœî : D±Ñ‘FÂréú“&\ëÌ™ƒj#ÈäÎ”k°   ‚4Ý_9¯T_BØš^ÝJ¥~`ì.¡!ÅccgÍ™¡ÓÆE—Þ>IòbjH‹É/4H¼tºŒ2“f‘`re]0ŒwGW9rí,'i–àVµ÷¤JùèÈˆ¿°   w45ØV o^÷eô°}CTŒ.áá±rN‘àEqREÎ&àT’â´(x˜Ø‰$›"ÒCÊÐÈiQ*Ï(O¹Ï(÷N¦åéºþ7Ç¾P_}¤4…€   Ç4÷$·Á
+”>ïb}jç¬Š4P*,X>`<1B†£l8D$XªÐøUFAñj˜(ØÁ,NŒŠüëxjËw©{Ñënß‡#>Þ ÐÇ-çw…—%]    ó4ó¿>^¥×Û´jTuCR¤£FÄ@˜hà@&?‡ŠÈŒ—^:t!FÝ @FvÈ„LÆHÖõ9J¥[Õ¥Ìo`½Ò+5œÅ‰ý
+Y”•ž%÷`nMaâ¿*ü   Ÿ4Ç,{Ùô#¬¦d“o$‘*Í€˜ ¡¼ ""ãbŸx&EIÈ<Ll‚fÉ½Øƒ°(™‚ï-3äÇÚ\ùÚ—6Ep˜Û©ê['DU±ZX‡    ­4–è†¼hÕ^úë÷)‚ëÆŸ‰–p22„X	¢6qÂƒÇ
+d°ØƒÂ‚m+:&Q*'Ë¡0­ÇCÒ5v›7{­§oaNNÍÉ÷{ÓÕ[á§Ëã€   È4¿tÌ•¢Òÿc’–ð%B‹=×Huár££‡Gt8‘Àë‡L…YÜ:ãcgœ„ÇÈt&aôPøœßåñlR[aœØú´V®ã»Oñžõoi«5    },)E	›^û	§’ÂiÂhâ(< hp=£C–0L.µ¶…D’"2ƒ/L36]GDÊKåðDj•õÙ:‹IcÞÌNw‘yˆVÓj}ÖeÜÊ9+Z-à   ™4úÑJ_ÛÕeä«»t¬¢´U#DÅH2`0db> d›Œ6deWè†Í qòÖ†$AïYšüx%çÌû‰¬MÐ·z³·â ”µyç-òE‘¹(á0   £4
+c©	³É§6GïÔFû¢Âä„*>Xl
+"ÓÅ„†ÐgÈˆ‹î.÷Á&—>ãTKþ$¨L—€T¬h¸î¶L
+£µ]WY\¤U2!ú    Á4¡—Wh`¾ràÀGJ¤¸YõB šñ pÈ¹ÀÀü“‰8jjbýÁæÅ¥*LØT‘¨2rP¨áY#›é¸¥2¹bëìœÅ,	kŒîí}{¯Ò™JN\¥Û(   ñ4›ÕÌÜnÜä¡=»É|¡Pà©`ÃÁ`0PCV#&$ÇŽ‰É5 :RùÛòÖë,+ËLx>i-Îü™bþÆ">õ¼N-d¤ýÙ.¬âw
+%&Ø˜óE€   ¹46áýkáV†kÔ±·âd(º0”ÄÉ\HlQÁÓ„J”Lù“&…˜!àè‹#—ÁÁ¯k	Û)æ·×úF)K‰Q¹nÝŒ†hržˆ¤xm¨Tø   ’4wtÖb²%~=%|ß*zº©ßPpdu8ÑÒàMqˆ#:EAP’„Ú’0@Tðã/±&(S-"1›âD¶I«³<TÀFSÂÖñöÜ­­Ãøá‰°HYÀ   b4R¯'ùÎZFÎÛ¹m_¹KSèŒ ><D22D_<arâcd¥FÑ0&èé0ëöt›qÕ&†	§ÎñjO'»”»¥½ùú¥“
+ì—üöcL\³à   –4¹¶YïN…<±ÖúÄ‰®„…ˆ¢2&ãÇÛ_0‹¢ƒ8>ld‘Ã)#$au¶².NoizV*ÅzÝxÌ+ÝJÈïÆýBçi84¤ßt   ¤4ÙºI|»ÿ©ÐŽÖ‹m…ÞA'*h	‰.41P€ÈAµŒ
+6ðë–FE	\„\<gÂ„Z¦Vjª/êûk¼syM30Ó§!æfsé³q…Pbb@   ‘4ô±Þª~+Ežç»A>ÐUÊ‡Kˆ:x© "42dc¢F3K¬PHZn€*…QÆÃxdƒÈÛ-h°ÌmØf'0½w«òö´¢öæ«ùo“W:E&Ñõ    ~4àß
+óW-÷ãŠòOªj2`d}£¥N‚Ácƒ|YÁ1ñb‹X
+$`gŒ4}òÂlÆ•:>ÀÚKŒnêlºIüšÂ¤B@üæq=8iÉ8$^q£Å1    Ÿ4·íÊ_s‚£Ôj‘¦Ö‹{ëÄ×
+ D"H4Ð'‚æŸf<é±U›6ma3†YŠ%Yg\ÜÝù Æ$mO%eöÀþ-Gù‘Ód)]¤Ð•4ÓÚ‹€   š4·²³T\àgV¢9a†ÛFIsÊ‹LA4Ã!4d	²HûL<`Ë³H´`pÒtŽší‰½âQš"¥jIcàþÅvÀÅngw¯tN­‘-…Jz1—)€   ‚,q´ÄÝ:„a"þ)Cðˆ&š0ˆù‘f8hÛO¸$ùp³…Ý)&(]3„Y nmHÅm/‹·jfüÎÙ£Nc¿0ÜJÂÖ0+lè¶h’€   Ã4es´D}Ø¾–s')UHH`ÈLeÐˆÃèDtBVÏ‹Ÿ9F%3}v©€±BÒ„Ä¨ÊÔ­RÞkôï,w‰	z?‡b1@!9xr/-ºÕxäÇjÖ—$5­˜j   •4c¢WÿÇ¶{»á>T%dÉC¢,6|^j…C¨/_Xª!AdJ¬T@ÐÉeÝ8‹çfþÿÞûôÌíµí­áµïóµ
+îü¯ÑDó›à   4ƒõP-~Œ¹˜œ¢AËö³ˆÐ>h4T|4”* =eäçEê&—Ú‰||JDµk‹Jvz”ˆ’c™ž¹×æxG(—×úÞïF§gþkŽ2ý<àˆÚ/   O4Þ¥¤­lÎ}­kev)LxHUòãH:ª‰0 LÁÉTbÌ¬û¢'TÙe§Š#ñ¢N»/Qó8†€èª‘WÁ¶Ê‰þ£1²fìIÏ&H–    S4	•ÔÖü;™|ÔÑvW'¹p¨ùñ‡‚¢…„YèTAŠãt+‚iˆªP¨Á—T`™´[¶p˜L.ˆÎ, úð:tOãü(*zË¤Y©ZÙˆÇ	ž    \4’+ö)Tr­c%«l/´ÚZà
+š„‡Bãc
+½ëÍb‚ˆØ*TuÐêµGX¸LdQ…dŒêØ©ÅdsÐHñcÊb[§Ð¬œœŒà¼BºIä`ˆÜ8¸   /4Î¡O©UbÛ"Ÿ]§RÑŽ!5$AFÔ•	a"†EU$¹ ÑólRŽ!´M%Ž4ŽgÌÉ›·ð{:„#ÿio!³=ÚçhVéTè=R@I³tˆ€   -4£|®Ç³/ÓM3O/,%ûÏh@ÐXL*0àèÝ*, 6®¨‰›BÒçÄœ¨ÚŠ)ºt‰4Jg*¥óŒ–›Á¹Z³p[Öc±yP•X²Ì˜ÅÀ|   <4ü§²íH²õ“ß£ñG3Ž•>2cCA!Çk<øMÀËª#x|8E¤iÙS0·çŸ™IýD‘}(7?‰þÌü†ˆ¡¥ú„rÒ    24¬Cìqÿ;*‘ñê¤ÖjDL©HÉpáôÆ˜ð‰"ø«h‰
+9HÉÄ[é!¢ë)dÎjùÀ–ÕÈ^¥Ž®HqS¬è¤¦¯!ÇT8d­rüÑ&    f,KËh‰Á™GhÌÈE‘$&C€ BË€)»èQ ŠE‡U³‚DÔ	-8eû‚Ç+iÒƒ¦yˆóÕl½W@—žuø{‰†‡¨ù~•f    O,4],ûr³èœîh§<ò
+Žá
+0j‰0\˜‰d
+1@I£-O©Øá¤)=LÂÜJ¼ª˜0_ø`6éUÑ\Ì:ÁOŠìB=„”@   b,#%ýÉ®Tnþ³‹ÂÕÓM		
+hÐ1#@08bRÐÛÅB:ñ8€óíÆy×Â¤SUÜFf©“­(Ç»Ìá™IOÓï#åú®Œ×2h7Š•Ås›   e4u cnmæÏ|-•Ã?Ê8 Ç¡“H@±EŠ„	8(qc¤Ï™œ£(Px›æ\;¢c?2üµûr†<ÌÞ’
+}"!‰àø€çó.zÞ:ŒÁRIÀ   v4™šLkrVkj®éfÁÌp£åÏ‚®˜Xñ ¨Ï•	¿Ht`A°É4®ºð±‘sf³‚ÄBƒ”“ßMÅåš~¤%žm^™¤þé)øüŠ´}Î±zJíddJ±    \4áú;Y1zxjC£ìZ¶ÆÅ›6*HÁ0"ç£Œ-
+£6«á6Dš.™Q·IŽ_é±'Š Ÿ§‰Í^E­öšãP¤‰ìß -³{ÙÉŠzúD#¹e/òˆ€   b4ób>n•ªLà­›e{0„A³ƒÎ
+’úDÇÅÃKú80lâTCAu<aäÊêuÉ¦^mbü•„kÈÒø^5éì°
+P¡R«7ª´9*çÆ¤ Âp   N,!}Ùß;hÈ.òÄÌwÃa¨€hpÓdÚ‘‘wJÅE	.[ñ0ÓH¸Â´CESÓ–Ürf?RGç«Ñ©þBqjå¼ÌKšœv€·ÆB[jˆÖŽ©ü   ,4
+Œô\Ž?tGMÿh·O¹É>JBh‹gÏ¾2cÌ4eçU	„¸¯O,Li$y}rÎ
+¦ˆ*6PøNTê,ŒþØ:
+°i”ŒUuŠ    74¨ÉŸšdÇ&00sÇuÖ‘×†›T âwC£$iAÆˆ¹&¼*¨ƒ5+Kˆ™qvÈ««²Î‚-àñš„Jüª|PiÐ‰&¸>‰"öb¢†I&…À   $,åI÷
+J¹iü¥ÜPyàj!€ÆÆ"Q2ÄY—(P$Ay7›¨Lò–„×óÑt‘PÛ–™9Ñi‹…Ëgû˜?W¡¼J;vKsÄhõM¬P,°µˆ   $,Vµ†'%”êíðRÃ(g <`ÁG*ÃSÂÌM0: ã"¦›FâGÐ~Ø²é|Šb&!2'-t©Üšç7‘•nt£oãìÏð¿T›®&4¾•€   ,^š%±Öª¤úâêÏ°,¼ÃÏpð@»*0±K…	LÀä0@jï
+'°„p…b£Û)Ø_g›˜ðÙ9^ÈÈ"‰J‰Ü•v™ ¡V¾Ž     4ÒÃCÙÕS#Œ¥Y,C8šiE×8&I¡"Ã|ÈÈ‚•M4œl¹ÆÇPÄsòKðl¢t’É$>'*ò‘Í'´Ü—ö~­IQMàTbÝa&ùîë£liz    ,/‘Fð­¶Ž©¥ôI2(0 x»`¦…„UÍ‹%HºãÄÅ•§<º
+›U0…ÂÝ,¼×)øþrf2‘¡†Ö(sÖv{BgÎR¦³:Ó’.-ÂNl   4
+é-5Â¡}Ø´ßò/P#Ø£äÖ•>œø²1Q©pYÊmQ”(™*Ý’Há{&TFD¯DåM$BqnàGöúb°O»ÌvÆrhÿ²0 \èðÀ   %4ñVæ#"x‘f‰¹cöïª(…‘‚H,4LO*²<†Gœe²¨PQç‹ŸM†¸]A)¤`G~-œ×ß½³NÍ1½=ŸÔó(Z³ß•d°Ùìlà   ,4H²³6¤ºî°º”3±u;öÂ†Ç’®10XRlÙ1ãåŽ+ ]@`³§Ä¿“¸%`ù>&`J‡Ñ !)Ž²•hÇ°båÝ
+Ú°87VEê¶‰Ì2a“@   4u²{Žvø–½VY0Œ™Vh0LH4\ðÄÇ…Î	“ìÐ,EÑ‚Ú4\$á¦*L^'3¬ÔÊYç=³+UY<"–0Ç¯ùÍ0µ3‡t¨ øÇÜp   @4öM\ä€ŒL—hìi¯IW,.2Hð	„Ç@~DZ@Ù‹gÂöÍä*¿œ2¶DHT•–´f=†æ×ó¢LW‰«½Loõ™Nö°%9¿[2Õ‚s$-Å‡ÅXˆ   4ãNÛÍ¶´ÙR&0¬¡…$EÑi[AÖÇéå:¬yâ‹mO„B
+1ý±‚È%³éYÖeR·/äâœDp·µ^³ª”þrÊå²½øÕD¦.q3€   *4÷2ö1"V²=,‹ÒÓH¼‚jÃçx`$6åª|@›!Ar¸‹‘Ycl©â­ãU|~T4I£h‚>ª Ì"u5NïlXÙ¢Cuà°P¬xYÐ   4ýJ·kÕµ²) §D¨¾bfDH€"`H¸Ö†D\‡RL`\LN "™E:` šM"‚K ƒsg)Šº{*2’¸¦ì†›ï3z³6ãlB ¦Tª@   4DªÒt‘gnO£­ÎZÚ)žDI!ñ6,,0ŠÌ	:©£ÂEÆ ÂY’älp™UyÊÙÄR—ý¹¨¦êÑâÏR;ðàFjENåq‰‚ISeŠ    '4DìfÍÇœØ@–;u:®Ä„K‘ºóGF ÁQ‘õj¦PèÛ]]7„
+LŒ#%0ùÐtæ4gÄnZ®+ð¶ˆìc;^Øa¸–5‰ã'<†&™¾,
+   ,àr).ÙJ_§¼ùø[ k<
+H@hËN‹%„2¢ÀA“k2ŠãE¹­“7Iº’K;„Ô£±*ÖMì/–~QëáL©¤1µ×([üÚÍÊQh   ,4³AŒz¢cŠ„9A4FrÈaáâ3&‡…%Bãd›Ä–L¹GWpê(l5œ›¨8ÎeÙÝŒr™¿3j…]5î*Îw]Ùx(í¹¿Mù ÈÐ3   D4ß»ª]ä˜‡…ô8Ozw
+v^‰¾>±ÃçÎ(˜XûQu@e••¸¸˜ˆ”‚"¬uÏ[cÉ¨ùšú˜æ1¦oï´¶BøÚ/RN³/`Y5høåÕ—    4ªK«˜ñ–ú_ýY”ºJû"Ae…H‰ŒÙ³JšIøÛÃB+»Ñ7¿ñcŠ5>SžžÔgÛ—©—föÐ+‚†wGª\éù®>*V°La'‚@   /4Ó|ÞÛ²Â%pGô|1¼.ÌXø‹â§ÅÏº4ä¢€Á+ˆ$.VèŠÔ„Ë!.\Y)ZO‰º_©úòæñ¹ä–¿úÆúuXv+ À†—X’ì¢ TlOP   ",#½b™‡J¬ñŽÖÙ)¨
+·  Î˜`ËGàYA•N$}'CD–ä’=t$ùLüFŠóOu…|§íPõn¥âTiµäS16,Þ*Ä*n`bˆÔ	    ,7RÈ£^”¯’@Â)‰:>0× †8<ð°@6&HEç*]ÁÑ"pTu­ìCAubUJ•º„¤ËP2^0˜.+WÂ¼rTIê_§¸H4h.&     4T§é*â<¥*­YñÝðDlDUˆã~C…OpsCÏ7â°»dßÑ3ÂF
+—Iƒ³·…Øâ¤×'øµn™»X¿þ‚Ó/ô)9&ò›­ùï–<6ÄÉF€   ,4žŽ@²èûe	dÅÇÉ(Y;Ç® ‘E†\‰µ\&F„ir/=»S%YQvíL'Òê·æ‚³Â#ad‚ºZ®†Âv×Ãºò"<$‰Áã&Lµ°   4ÐÁSZeÓn®êˆw¬ÁúBŒàD³Ž´0(q±AD¬4WAl 0ø´$…ÁIwã“RsNT1M—¡u~ÿÛÌöŸ¿3¬¦Öôç¦ÌÆ&.	Uà    4e²~7äº—ÈXkâ%h9öƒ…Ž AˆTÃ2#XXtQ¤4ø4Ú%ˆµ…¦è®X‹Š$j¢­Ñ+5'7ù¯IV«¿¯äá	j÷h/ˆ ï¸G×n†œ²·€   4gæhÉ#³ÿ,ârÏûò†…ŠPa‚áebxXàÀÒòK$ÀÂ|‰,²F„#4Þòqš´dämÇ“×Šð…ø°g^è4üóGo<8@|†}    
+,3„Ÿ×°–Ì‹2<0T‡Š2,hˆ!ž‰(bì¹xãVÁjô²‰
+Q4D¥H®ýd/KlHLtzÚW²Ãºa:é#fö÷7d‘ YC6|†    4	ñÒ"¿6¡½DP¤¶Š^³É›(Lå"ËŠÌ‰ôKH¯p‘ÂlejŸžMBîþžZv\{Ã¤Z²@éYž›häÓð€é'ÃøYŒ©²f    4’—c¬×¼¦˜'™¥ÍQv«]2êR¦BÈ¡¶Ð—gA$VåÃ—
+ˆÝu=faÌ„Üì¥rbµÍô[gÌ×¬æ=-;úÄIîe†ó´øï™ ³    4²žˆ F(ß„Žø‚¥Ä©¦á‘R6ˆ–¦ÐÔžu~\©&ß/·$Ø„‹ÚÐf<¹Â5Üñ™´Nÿ@Z4gÚ4]7rIþrñ¡¼hŠßs*Å6Ÿ61ƒ    ,!ðâÔ¹6§“Ó`‰$èræ‚MƒˆL1!ªe˜u:G]²	r}×Ê_QvÓ¢Ú>î„Í•þFAý$rU™—SvËU™u¼ï¨^²/è ºÀ    4uËí®©M*®}›ãõŸ—}ÖOyX‚…â£8DÙ¦Z@u²ìX£&NÚ¬Q›IgÌêE	±g‘JÑêÆÊlþ‹KYï­òŠÔVeq‘FD   ,LÔc²„§Á‰³ÔK(D ¥i£
+(€sŒ<ùâ<8À˜±×%ð¢Ö›ÂÐ>Kd®ü“!*EáüA¹°n™m¢“qeDž.D¢   ,8*z…?
+±Æ¸.ôÉx˜`Zœ`x”
+ qfOg‚&yPÑ?‡·
+°²œÛÈßFrP¾5úeQ~ÿ¢{iBÿ´‘¼GÚHº´;‚ hk`    ,!„9§^=%Áåù#£
+hà5EAd°xÄÉ–“h‹i“›*ò«nI³&­–Þ€Ë£ØQAmkŠÛ€ŠQþìÙZ>lqi…OVÄ'ÓÊ–*Bß(    4G'Lò©£KÛA&	¶k;â hM‡ÅYª3çr(¦è°$›•Wôê˜	ªÁuF2$ßLÒ™2B”;X~Væ,Õ‚—ÜB3 *ÎõN¡ƒf    4Dô¼% s«`yd1ýƒgh>â4]hàAK³Y+eÈKÚóEÏFfÑšK|ƒ|Ò,÷¨Ìoó^#…3w8ˆ
+ê.L4œ£ˆ(´¥äÆx±Ñ°   ,"<
+´q
+IHQSv& x‘z
+XA$ÞHÐòÐ¸¹ü@5ú˜.	EWOàÊÍ@Á“'ØžiSOA~µª',J÷e-ªó&ÐQ3Q5è
+‰€    4UäƒÔÝ6õ”Ù$k¤·cÂ¢fu P@L Ë>è¬y‡Ì)]÷©/Ï³Ád®Ä“+8Ç™wôÒ4+%ãI‹sº¤èÐ#ß%U¼“U›B’e"C&éø   ,!3G‘ˆ„Û1¢©xmà@»‹.³_+ X¡4!È¨eÊˆxD·sDÂÅÓ3‚EFkÔb žH}8–‹>5°d0Ã¤>ê[<±,ãp   +4©ÑÓRÇØ¦0¥ý-"¯’LYw"LrÊ“ Œ…%Ô<'°äËFð\\µJ‹61(S}SíÈoF©'îPg*ÒJñoÓô&.Q•6™´6   , ,ü×£l×¾=gæ5Y^¶À·2oP&<FãºEu:v]»Ñv2Ç'ÓëJð’sG¢(,'Oâ¥ÿø·…ÛÍÿŒ+µ¥s u–Å<0¼     ,
+sÌ˜j6<çCHUk
+`IGÒHÑŒïV^.µE:ýâ;5Ô$“f¸“#Bp®\DŠÊ#ZƒjN†óÂŸ!fMI‹¤
+#„ª[¡(XAªà    4É¯‚e‰X*ÚÎ|FTä“–ÑAÌ¹€ÐºÈ±ƒ8k¡@ g……Ü[Ç4Dõ²BÉ$ÙŠOÉÐ	t¹Q*FËpª„Gse–›¤YI¡Ž>¹    ,–2<˜´Ü)/RtÛ‡L´
+@”þpK·‘F¯D0)ÖÚÉP]¡™DIˆõâQSvùÿt¨¶b=•J–.$ÆÆœ
+S>ÇNN‘–")åšP    4/\«Òh§@tsc/îMo|Ñ&ªr,Æé¹ø‘*%ØÓÀ‚1¢úGFz°_‰TÜ¢Á,åNLÝ‚›Ù®—üxüŠœsãˆÑ(/Pòôè~Ê[ŠäM     4%e£ñ¦5Qbl˜3…‰¿üâ»uè©Ú	¨	¡—df²ºgã¦*ª-h·WMPN(äei?¾}àdr‚~¦_nZhškÁT_ÀiI¤zˆŒL‚V@    45|€“	¤ß\tWª¬±&ÄÓd»tHœÓ#g.»,oÑvZ§B;éKFqXÙ
+—æpöó&!ÅÓßè3e±{µ‡ÈÖ¢ÇÝùiWbÅ$Æ† »à    ,(YƒÐU0±¢UáW¡ˆ
+ƒ	Zˆ	1!b¸Ï65gL4Z¸'áÁ’¡çÍE=Œt·ú§5‰hDz,ýk¨Ûý¦GÓ²ÇS‹š®a/Ivc'¤    ,$) &D<ã	$¼0BM
+*S’¨(±VÉ-~˜›–iiªÂÆHïi(‘Î™€©“4F‡ž˜Ng’®TBû¯ìt±[! ¬’8GF,‘â     ,†%È‰,4Èñž%µ]ðÔ*¸Rÿ4ÁPf‚	sâbj7]pÔ…\+Ÿ±ìN©}s"¥ë-JÉkðééAX’DnV<GFn© 4)Š8   ,&Ñ‚W¬N¡j.P™ª¡î…/ÁeŸ±@Òi¸‰AŠSäjÃDf m«-¢¦È*®to&´]¶OÌ[&ÒViŠ‘'@ÀŒEšjU·€   4é{iªx\´™ˆ“L1NË”N-ùò”‘üÊ¨úŠ©$+¨¸°¼ÁšÒê' ÑÙT÷'IÚòfª’r+8ßA
+k˜ê6¾BK8qä¢AÈu›"cD¸°    4Œ”œnâbÅ¡ ÔUÅ|BtÅ’SÌ\!4–6Ý¡£ËÉfé…¤$DæB+ÿa"_¯yQ©Ý'ú™„Å¨‘”MC¶Œ%ŠlK¤”.ú2÷æ=*sã4ûá`    ,!åšBÀZ¯T£6®Pzt0rå.ÿ*PDQR ¥ÊÈ¹";ëTêW0€#ãZŸ‰žgñ?¤VU“¥I/ÛH¨©N">™‘„Ðz*   ,°(Päì@ÀCð0›Ô 4™ü(zd4ÚÎÁTÆá‚øW5ùKQ ¤(ÀÕÔLStÐHa¨ØÏî¿¥u*
+Vi(:£…_V0N›½
+A¡‡ˆRp   $,á'fÀ¤zHZ¥,‘4MBBJâÁa’GŒà·Î¦Œ‚˜ØêH+i˜¹/˜ëÿ\!pÕTSµ7bB>T{‚¤õFâUj¶úNì£•Bh †^    ,	Èa!`M¼ò #ÿsÕ‰aÞ ³*8n—ñÃÀÄ*‹Ì}áÜÖcÝÏÖÔÎüƒ$l¿!2K’ô¯ER£P›šåˆ³|”œXu´m†¶
+8rNO     4Õ,+$™cd]-ÆŸÊâ
+dÀDK‡?g†Æçù{rj«‹äf‚:ùÅµ‹Ð~©Þ¦%J]>¦Q'²) %š‡›kdÏ?…‰^)œ X©2$ë´… h    ,))†ÿ‡¬ñI²Ý¸çùÁœ³XœÊñÀû†?ƒë¯$;]$ ªÔ`n` ÍQ‹Âå
+Y™‰ÂbÊã7bÕáh~Ê=!)œ²£Bà’„    4–4ãç“FM¸ø‚üWIãÔËúV´[Ž¯á-3î"èÓà¿ž—¬[‚‚6O‡,3%¬Æ¦¥4+ î0èÉ+ËöœÉaôÕ*ò¦Æ`Y±p   4Z(™g“®&rÈ“ïÙ$cSõHÇ%_«Afå±DÉD$Øˆô¼¤²%‘¿\»¨ÛDIû%ëöYèÚÁ
+3CÛPãƒNÌ5Iø    4P+”T‹T"/(Æ÷À€¤jioÊèŸÑùcAþ"±çÔ/€ùA LYs^&k°Oß`Ô¦wEåòƒÄ•#d£ýŒ§Oè®,‰hBe    4ÇàÈŒˆTýÂXË$¦ÂŠ¯[Æ÷Zc„¸7Gj IHõ]½Èü{víÙ!l¨žy;neÔÍ§.)-hª÷E]¢¦Æ­ºP‰E,‰Ä¤q”     ,R “.[jp,
+˜ÁmùRÈÂlªÇ4D¥ëù¡¿	3Éé7nâÎiëêû@ØµÂ8ýPl²`v»*øMý“0ÚtÐ’5BLªÑÀÊiŠŠx!Š€    44‘SÊ…P–n:xF—¥di¾‘lL†&¾ŸÑ0¦HöùÙÚQTxz EÊïö¸H9$#A»bò1W6<|ž­ˆ&Ð¢DNâÒb`   4þó(²U9Ó%Î;1§EšÁq’²×Êì¹Q–¦owsºbh¿ÝãlÕnÜ)Œ•æèN¨T™*“N¢(Å(›¶Ÿ¼d@@Jˆ‘æÐ*"…¦!Q¥ðpp   4²“§ÅŒ‚ˆŒ€àÜaeTÐ\øÝw%%D§ŒõQ‚áH˜ž4S¿RºLäŒrÙêìjƒ‹GW‘š)ƒšI‰2&RY:mÁ¦Ñ‹)œÐUè0%BÙ0dHz~Ÿ€    4&J"ÕÔ¯ ôÙ²”gDéø2!•÷kZ…Ž]zX-ÞÂk+×|:*M“n+C.œÐ&5O‡Œ”°¶g^g¢Çãdl%$Á|Äé?g¯¨SS"ê©“°   
+4¦¨“0Ð´›bEŠ1i:¤qê³bÖ,“L
+5Èn6^Lv€¿©“£`½;¥vdB±½¤`¼¸ÏôI[‹<ƒR-RFOØQ‹/ß$&nŠÖ	ŠóÃd€   4’Wã,Ð@$ãÜ”¢Ò)÷ÇÇ¨ÄDk/Ê³r›¢VÛcÜx˜2<òàŽÈ dFÇ$Ø#&=xjÖJŒÃ«œ34·ˆäqÒå‰’Ä>ÿ¬fäT.6¤Ë³    4•Ú<”@ŒÀéRÔ²‚ûk²–â€ü¸Ý¤#8±îøÝúh\‰hpñÞ/ÿÑj1çd¯½¸ÜŽíâd‰98B,Z‘–¥FZ´ˆä8õu¡Ñ¶»L    4dÓ©‹^¢“ ˜±‹òvl)dÎ™/YzhF´²iÜ#É¿×–ÉŸ¦RÁ\¥	zW“pf¦ÜÒ²cÄ,¶è±n†Ô(±2†$GV²²J5¨‰ä˜    4˜Mòœ´P¹²·­X»ðl–5¼æÒýÔk©v†’Cc ß‹‘ªzfe üÐˆÅ2dU4,F»®”y`šG¤$=$hòêOhÏB     4 ðUa	>A@Š†O~\KdmýÜj:/,ý‹àâókY,çh{¥•’ÞšG„ø¯6R*^Â3t‘=‘¼tãK3lá±§Ì‹-€¢<$*@TÃÀXlÆF]€    4F‘¤)2v¨ËUÛip K½Í	‘cf4<;ý–JðF¤©Ï»7[[›]%@ B`Fë<oªD­Ò±&\fè³ý›x™Ba%îZÜYQ³ô†ƒ£UòG     4ºYBk¸Ê;ˆ¯pš¶ÆŸÉë0¼Tk†e7üÕa±Eq@oK›ŒÂ¦ì!`DHˆK;1·™
+o1UBs«¶0¬Èe©ñTF$°HDâÓ§@    4’\y¨dðùgÒ%tKh@^¬.æAi_«ì|äÊàg·Û¾3ÚÍ„®…±ÈRDÕ$ˆã¨£Ñáþ»a«á
+é¡•ÚE%I$C•ôj³‹Wo*9ˆÉwG^Ð”Ì   ,
+@±`Y0Óí‹Y¥PðžLÿ„÷²iÈb1%—¢ö¬5¢ÿÉäB‘ÏÌZ™ie('HefWKˆ£ÌÛ"<„£ŠÖ
+:|n$P²ÑR‘P˜ðÌbp   4;pñ¹ò
+¶uLNdó¨Ñ†)hþyü%2¥-è S[ýÒpîS¶CN7ÝúQ4;¼–ˆÌ²–#ðãþ– y‚,ÒpÐ”è’¾*fÊ#d¡Ð   4ŸHÊ&ÄPD¨ÑŽN?qÈ\ð¥î];ªtY•{™2ÏöµÉFìxï²vLrçxV9(ïRJ&HjÏ‘ÊAMHˆ³ù²(Ð@2qERô±ò²Èg’/N€   7<hIS™©L&{\&:ÔÙyD°Ï±_{¤e)N±Ž¼§Övt«ÍsôR?/™Ã×zs‡k.PEeŠLàóÝŒšm3D×›2$ll°l*³,G–(Œ“‘ŽVÆÕ    !4žrùÕD¾2™Ö\”^°œ(¢°ÏÚ)WQ˜ÅÊ:›ÃÄÈfþªn‰ke¡œx
+›Òá1é‚M°É†DYÜ;jDQ±ã¤†Cq Úž…‰FMË2;¦’     4JVl2‘Õ¼úÄÛ%i#FÂyuß:Õ2×®ŠüI¢šxÀ	­#»W7!ú{%RXh.râÄ–<QÁÇÜ¸À«RdŒ806²ZÌ@LôÚN´1µîœ    R4x,¼‘Òo‰¸T‰5Ï¸m®[û~èç‡c]~šY¼wh”˜Îü/GëwÔ×,Tžo£Ïô(2©‹œ:ŽV0PÐ¸iÖlK¢€QfL281a„D€   J4,àš$„‘ˆ‘(²D~#(9ƒÞ¥¯$ðJjfnP5G© NaS)=ob.‰Ë1€ !!Š+iàƒGO5 TÉÖÒŸ,>j\q“fˆ°hâ ¸ÊR6\   T4iÃ#™dÉ3èz¤ÒPOy1fÏÅµÛ)žÿâÕókßè(KhH^¨zš¸­““©/YÆlºPã,Œ®léõ‹¬Ú xÊ’¥XŒ‚ÄEÀ   e4K*0t„ÁÖ–08F$å¦pkZšŽð)íT«s5.`ì½q¾¬rUûÑœ•/‰ÄïÓ!òäJ‘621k !dHª¡$• hX|ôˆ4× Üò.…0U¢À   `4Œ.€Èƒ¶…ªêê ‘*xâ¼·Ä,ý7Hk9­m^Èo:ä+ñ-ajü/¦Ô\=œ–tcÅXæ>ÄdÉ³Â„!…¥ÎˆO
+:@\ìmåE‡%'¸^   h4Hde·…Y0F(0÷Q'8"o]7àÜ_dÓµ3Õû”Õ|Ùà¥ÏÇx%q/.|¥œe¸4ÙXf&’B $àDQ´áW¶:ø*ÌT*•…Œ C@   c4	¾XQ£pŠ]|.õÖZäm5n[Ì#™UèeÕiMZÒwñ}™;ZOˆÒ VÕ#ˆJà×”]²aä'E
+©*`lA	ò¢ñí€‹sMœñ7¡œu™P   ‘4xØ˜âRCåè6daTr™jt)©‹½¥¡­\‚“"Œ¿ùÿW:¼ÔË	ËÒ=M™=Ä)3'Hx%	¼DûfA”È
+„5ð ¨ªQ˜šíFx‰v    4J6À¹£O)yrÌ8ÍG2ú¨F¿‡äxÉ/æä­>¥m•žÜåµñ«“þÿÇÈgÌª·‡ÖæâEXtÚ3$Î	‰:,‚A‚$MˆˆK¼ø$*J=0   À4`6XHZ@Ñæáeª¿G¶¹Ç9®Â˜Û’£'ÔÖ…z¤žŠ1ö_þF¾Ù^¶¤=°È;oA@ °ÀþV“- ?#j¬àŒ¸Õ`„¡è¡¶ÑSR¹âL§	.Ç)%è¸   ž4¢è©×…ŠHL›bÎõUB´¥‘0¦öªuäÕžÈ[uZ—›â°ÆNeÕÿ;ÊŸ*Pu2ƒD&«§”‰T‰±ÏÃDþT‹‚BRäÑK)a   a48IÑ’.+fŠLŒ”ÝjœëÂÖ²Û¹ÉáŠÒÞ_qDsñýªë‡7ºÄŽ…•£a/‰dl¦±âÆEléAEÊ´|À‰tÛsÓe›´M›ã.ÉÒ€   l4Ž¦.ØEÓ&„WíkK¤*-^ˆ®õ:äCÐk)±1§yÌasVæ"@ˆªò·ƒ#P/…q#b“X Ù£†ÄÄÍ*|`x³¥ÅLŒ p€>Z.^E8ÚäLŒÂ€   l4„F,I‹›A‡‰2jó[Š~Ý¾(b´¶ô·‚û…¾:ýD>xñiñŸÈÖ+Iy"©W"@k¾…óÂ¦Ó®àñƒ,œxTûtCÉÜ%`„™FF©I¶€   ¥48™â¢¬:ÒPIbr„¤ÔæBÀÏõès­àB€ÄêÿC0¾r€SzœP=˜¶Ap%ÓÄ[ÁB£(Èžpk	P|ˆùæ'*Hñp¹ž¯R(®âÅoŒÃq€   °4	h8¼ús'‘q	fs$×B!p×3çH=”Ü­{ÿ)£5¡[~€såÑA€T¦"‹ÆS 2†ˆ<y°Ñ6#e
+,D˜êŠ&š‘haz…ß“¹Šo€   Ã4í86¢€Š„ÇÕRB,Ý·O×±'ÛƒÜU©~zn‹ÈnÍñz•'{¶õŸŠH/*?P²Ÿ=<PaÑ×	*<¬"tØÉ†D(L4„™ˆÂ—‡ËGÆˆÌ\¸   w4íW£¥ÓÈ®]„_dEç±”Âæö&ubvi`##cÕ„¤t=šÑð=‚9 M’FrpÙ•˜p©b¡äÄÃ¤_2e)¢Á2îæxDš"nI‰•’+·`   x4v%š.$s€ªã,ôÚr-Ì<fgúZMh”¾’øM£Üçh½G½«ˆÀ¤l–À(ÀRù
+¾|û£@pÚÐ«ãÂ_"Xyg‡Ÿ4œÊÉ†SFÙt¸\Þ"@   ‘,)–†—¸Y*p •¶TÇ>¸løE±&|ì`~ óù9fBžs¤æJ—†S6Ë“æF™!— DqI™*²çÉ.ÙÅØž'Ëh¶Ø´Éí    ®4Å—ž	‹WµQÂÊJ!,Åò¥³•£QíÎlžï¤Õü“(; á¥¥¡ÕO7—E1“Z.86!S.t6mÝ(&B"irŠ‰®*‰2¥&]:à¤21>D—    a44p¨¡Ê‚©f-EJ¡}¶v±ÍMp=KAé¨Hkßdë›XÛ…Ã÷“wsÆY­`EßÂnÚOˆ&*`ÙEŠ’.&ÕCîI;åˆ]\u!¹Á”+4R   n4&€Ð™-ÄP]ŠËÖ]*„KYÈ½.>Øk¾F&‡êù¶¸Žì™ˆ~@‘Ë¢ÍÉŠQ$¹Aª‚#R‰ã."&arë¸qÙ7ÈèQ,Û”O¤7Ñ›'   ¤4%0$<K)²ÍDmÆåYsÓ˜Ò„KGíû52†AIœ’Û}]ü*ºq€Àz¤ØîÆ\±bÇJˆ…‡Ž…0Upè™gF&Zx˜ÈœDO0èÉEx   ],-‘aE¤H!²CÓ0âæ¤ë8ÎFEX>es&®=Uò’òŸUÐ‡Aðr›kÚ1Ø‰ÁŸM$lMrÄF,ùÒ+Ä4 …ÑA$œ`"©m\R‘Ù”‡Ehv%)    74 ÈUŸÄÜtQj..»õÕ-ÞÎùO\xÂrh#^-Lz×O~çÙ :T{S!#·,2 ˜‘Q™|*ÁAuÇŸ2p]…$Ov*\z`ºì áÓœ/1C5’    *4“	•dTàuBBh>U´N=°þ¥º“ìSšS³Ù¼G¥¿œ'ážœ‰d¦UºZ¯.ÊŠÒæþÀœ¤ÁÑÁ ú–?4|Fdì¤˜à‚ápµÆ‘cQ„Ž¬¾Éî”bbVÏ€    42\`é“.¹Fˆ®çe¶7_œ‚Øý%äÍû½i~ËÑ¹¹C%$:ªC€,rÕAQ#b¦‡Ed:tèÐèò–ƒ„êžW HÒÿø9<8Ä½‹­Þ	8É8    4b&†ÅJŽ6X\«Ë>$›X #G%+{{ê“z[þ)þ3BSêSìWÂ"9Ü¹s5£¢P€‘ðÀ@v„&LÎ„Oœ¤ ¶vå	Ál\ÐŠE.Y^A€×­‰§‰ÿÓÀ    4rGG‚!c¬‚HOš"&¨1žÇ»‘¹ß¼½?jô4¢Å….Ät¼Æ't‚¦qÙ-‰#AsqyˆèÏÍ‰Û‰Ž1‘¾89]ÀÎ#ºÒFä²_)GgQÄg<2Ú`    4 EÂ¡˜>
+…‡E„%'‹±áb|._ë1]$ÆZuÞxnB&ÝQ¡^æú|!ôëËnÍÚ
+JF'ÇCªÌOD‡	ÂÑI¤€ý!5 Ô»•9ÿ6Ñ.AÚWßß@    4‡`øUÃ"Â#Äš`«oäO	S©ÞÖäæ-Ô¶Ý’¢?¶XnX\©6‰ŽŠ	‰à¨íO_™œ–¶;:&%;î3V·Ì ÖMJë¸GçýE\[a?ûn°    <äCóbó±ÉAãÃ´«Ÿ8ÊïVfÝ|âÎYC2”=“÷*{{l†ø	1\²¥Ôˆ…ÁSC@l":“òÃÑ!Q©)yy‹•º,Šh¯1õCY–Keú_a!“L¨S²X½     <b3Ñ1ˆø©Áù‘“—Ì_µ£Oè¯WµîçäÃYw~Æf81•ðebÌ Q²D…Ï‹ÃãÁ€øþ:«.3\r™^9Q­üøÒ|¡I¿ÒJ&sé=—Ëª    <òÃ±ÈÄìŒ¬n~ðÌÔ ¥i”«ÏACç'¸¼Ìz•¾ú»W[“ÇOBh06ˆ\ GÅÇ¸Lf†#"dL^¦…ÊvûPUë2´¡¢”Oìn¢™´â7¡Þõ#U    ¨<ƒCóaÀÜÜ°jefï‹É(Ôƒw?öë³·ë¢e§e*dv¶§íÓZ£È¾Œ™C…ÈIDÂPIáÕ	ÄMbwmN›,\­nï$0¨'jë‰ÄÞ-žÏc(Î”UMþ`  O<¡ ÀL†"1 n Ã÷¢‡MÓüGqûAçêËÝ2zi—›žübó´Î]v|‚qY13"#§‚ƒ¡·Z€Xá,Ñ»Á3\|1õžÎºÃlÊQ2óIf1|wÅP®>¥gSuL  <FÁÜH~2£r£%ÈÖi´óšÞ¦Î§­ËKkPæÛ»$‚"k<*ËÂ¤K%àa ú?bV]´\G‹šÿ˜¬;ü™à0–^SH%W’Æ9‰ã:{èoÅ+  Í<æã’Ð¼T+Äa`Ä°^|éÉñ×ë-õô’™NjIDÙ˜…îãK‰M­oŽkqçn\Ë‡Œ–¦ËÁ473·iÍ9^¼/¿ôûaöÓÝ4Š}ÎO0¤“Ì")Üæ(¡ÖÍn¼@  \<³ÁÑ˜L¡üÔH8ZN&eÎEÂ’mîÒAiOUo3°¬ÿRÖÿ:œâfäsBTº,©à»òvy¢ñÜÛ½	^ü4_ùh­éOiCEÚžêk¢îSw0®¹›MdT7\,ô  -DC¹<æc:“KG7rÀ€H4Ú™IèTŽÿjåeïø¥rÌ5LÄ¾—Á©¹3ve!‚‹`‘$ôøg‹ÑŸ}ô’¬„ÝyÉ®³WÛPYTÐXó“Ië¬oD×2ëiTÆ3¡¿0z@  Dû9\Ô`"”ÈfƒÙ„´Kwyf#¡øÑ|þ¾,t‹_Š`ÄJz5¾³Vä;§5' A7:]EpTØæú[Î’ŸGîš«µ—{jï´Ÿìª·Ò\SÕZR\Q×^J©¢iÖI§µ  1<Ó£á@€Ôt*Ÿ„Ç„â‡OPü”^QÞU\Êk«ä¶3?)Nû„¥m2]Ýj5oØæ®ù®;Þá-"Wgc[šßí}‡ªz¿”ªhø\èWaGIî¶×oû›-\'8³íÆ  ¸<“ƒÂ¡àìl$„Cc	Ñ±Cd9ïä´rKºø¾žòÆ¶`výùË32uåvÝrq›µñ÷!OwŸ•ÞŒoyùéÝÈ|ÈsÓw™ýÏKg¶ŽÛq¾&óÖÕØùÕ¾WÿŒÏÑ—Ö  ,<Ä%EãA#Áa{Ññéƒî—þáIúÂ¾GAÊëôÆ¡ŠT¬JØ©£‘-Wÿ¶ú·çÛÐµìŒK‰[ô%e&öB- Õ®#Vñ7Í)|U½!Xœ­î¨aÀN·õ†íÊT   ª<
+ƒrƒ)»±Ð˜±¡a»/„GµÚåe9¥ÏU2¬+5jüC;2»¡–2xêÌcY:qks°Ÿ¨…Ù‹él9bÍhÅº!.ÉÚÑ®Eðr†Æð¥O¡„-mÜ  3<ÎKFbsqé¡ ”TLnøÈFÂ4_µßùù)¸éAw;ZøŽëåu/I‡xÚÐráÒÏqµþÛvÙn»ÙÎiÊlþNÿÒÓùëE‹nrÊDr#lªˆþ˜Ô;´þÙ	¾'Üˆ  4ˆ0ŽÂÂDŒ8 “wkàìý¹ºñj²³¹­½ßaßÏü‚~»ð'À¾Û!šz½´öºì$4=iæ;Ð)ßDdb¾$7YÛ³LÙÆ‹ÚÁ¦öó	Ì‘…o   v<
+>—¥´#:š–4dr*~ù%z+¤œkoigTIuÜüé'¥®ù£Ï=Ú<öí1ó¥DQ.ó%ùymþE6)¬Ä)ßðVç}ÉŒÝoÄ²£såé21\Y0dŒíJZI€  4	«&ƒÍ>©ã&Ô`Ú´3!)ÞÝÈOLKc-0„¥J3V$©Ø½%‘RXûz€¶ü	Ü–’Ø%-­)I¨9)|Œ_bjàb«˜ÉY`&GØ‹sí#|‘è¡)²ãöÑ\@  …4"ÁVr‹¥‰£2O •§Cú]•ÐjÜ¤åºR“
+YòzZ½ÙhYÙìý öx³žC˜ÓgÿA¹…jÈúÕ&½t­¤”1â®X8ØhÝÁò§Ü¢øÈìË‰À  D4ÇX­ÆD²¾Ù,öeë÷sœúwËñ¼ƒUæý¼dæ¦µ­KJÔ5¦1î`y@¦ñp•N“­ôËö6vb¡Ò“QôÚ_¦I¨bdH«`³Ö¥ÜÒ*Sp  |,'6Fˆã
+åð—W?’â¡‚oàlÜ¯”åþ6výKRÂ†ÔUÇ
+O–¡¼«4¨n^n.ò9w8I"íïamÒŠ b\¹³˜vpˆ¨ÄQ80  á4
+ù#}P˜úW‡©LgÀÆ»ODãxßMIõ	LÌÍ™HcR<3-L/ŸVŸ¦ž¦€JNHo66™MJ•F ‚‘GZÇ ²_0.:ŽœBc©?-x  Ž4V®Njo?£4¥ìiíˆ†«yö^FvwéÜeà¬ÏÎÃ}ŽÅ¾¦3l3=ì[fóáÉhJ§¨Åž±*´9Ðö¸"#¬r–¹{v¤ÏF[Þ‘	ÉŠX%("   ¡4ªh;)åÉy/'îkBBíoêDs©êÔ9¼œý	‰ŽÆ~•Ÿ¹+¸Rb¤Œü×Î¤+¼óÞ¼©c…RœFtâUy–¨TXŸõ®Ó³!tüjzíØ¬È°ññ8…¨ì‹š   í4ý¡b~µI	[Rr{­¬IM‡e:™‹çb7R#1¹[×¡	»—¢²±›\K_¡Ê´<¼R›GÌ¨ :4Lu„nÈ˜)P©šeë’7zÌýÉ(Øð€°àZ)(#~dH?æO@  à<µz¶Mwl«ãúŠŸßê*º;Ú~ÕûïÎ2[3yÙbÙSÈÿVÓßð°«Ùq¿ŒÛ17ÖáØ‰zñ¹Qxù’‰P%âˆVO­œ.)¿=ÍÉBh¤°¨ÀÜ˜c   d4–d*ÈZðzC9¸…›“4²óè…yIês²šE!êñiÈ}WÜUÒÜRÖÑh’ëU$ÑÙ®\Ñ¨8;hTJ\xj?ŠI‹¤Dlèz"Z 0JJ8†Ã£rx€°„dS•l  é4;-€ÔÎºËcFì¤Õ½³JŒKj[ðÄõÈJa/â’÷$ç3½"ØäNRšDk’,ýÐdá‘@ÈùñÚ"f©O„D¼ô‘¾ãw¤dƒaYÌVJLZJrÑ`Õ¬\°  ‹4«)z„–š—ÛØ–Z…~¢+RµÉ›>ÎPÀ3V='4èN]ÐzÏ*Ò¤ã\¨æÇT&MkU	–.0xbdL“ò …/~œÚ ¯$M4„Aa‘pA’² «  h4Ærj”Í’w¥^–ô+`÷Ó“Õ­ß™¡JRNN94³ë1Ú»y!¶ì" àYMFŠŽ‰6(ëDÒ­JF…IŠÖ{û;dP	‡†‹
+ ‚ñÄÍ¤D  «4
+ÿ½Ë2šXÓûšÀÞ]Ð‰^ 
+[©WiúÖdæcš/æN´p²ââ•(<PP, ˜&¨D¸lDg¥
+¯c?­W½f®Yèúè
+ÆÚˆ2d©“Cý³Ð  ¶,~Fxo„îDéHßC=:3PüÂe\
+ôt\ÑAE²Á7‰²ÃcÅÓ8
+:yP‰WAb¨l$7l—v‹ÈôäÏô]×þ“Ô(š“FN‹§\ÊéL¬«…à  é,ÔªpQÝ³uÞ*TªÃµ„jDtTêã'J™òÕuI…äÈ€ Û!èP€8q°d@°,`8øPeH¤ßŠÜ¢Ÿ÷-AlçÛ( ]—:óÆñ¢0  4uíª¸ ÏÈ¤'ïjŽc#;+ybN´äõÛÓÞ•6Ín5›H™ H™	‡E#Ñ #0/	Eì†ƒ¦ÍW,É•¼S“Ý*+H>2• HA—ÍŠ¬deC  -4_Á¤u “8øŽ8¹mÜ·2Uç-Ò“±/<Jh´îS®‰9[‘
+¾C	ÉÙhðNL	ËÅcCbÑƒ` ñ± êä• "Ð.³´šV|€të‘×\m€L¶£@&Ð  n4s–ÐºÙÈ’éó¶ÝÌû5d&ò‘ï9—¥Õ¾ë%ÍÍ¼˜Š‹B#gB‚çÁ@ø@|<ø2"P|"De¨Ð‹Á'ê¦.J˜.­+ ©SYÆ"fXtd—là  .,aà‡|0µöö"‰‚{l'±±O²ƒl‹›[Óól±$%ÄÓŸ˜*AÐËÅG”Ç‚A†Å„†F–
+"P?@$«bÅüMS„¹jÊÛ
+XÔD@  A4SÍæ­áab¤Ú%ƒ˜)ËÉéi‰½D#~Ä/ñ¬eùË&»#ä‹Œ,><t`2B`ØÈÅƒÃ`‘@HøˆlPlêRA¶eÇ¦*ijMpEáóVgdFÀŠ  94mƒ%i	+ªTÕ0†<+£q
+µ;‰ÈZê®R“îÞzx:zqë3	×•8èø‰ƒ‡‰Œ†ƒ!QQ˜„I…EÂÂåE‡Ì¯4LM~	
+ »ª£èhg1‡“ì)  ±4P.c$hÊÊ9ØÐ¾¼BwîG®\›¹%ît|Jnè}s!"¢£u ‘w7#3AÐ´Ð˜°Zh`hz9ô@Pdx~)4*’ÖÎQí $GôÐÁ†[D5tRØŠÒ  4N¡f'"õ0Þ”ÉP–ÜZWúzÌÒ™¼ã¿5’šöMŒÑl ÁÊ‡ÆÕž&°HØ¹°@Á`AáñC6|™14¥ÂL$”ŒÝbÀ  4>‚µž^]¥X$ãŠúN_qgù›5¼êÂiX³WÑ\«ô@Ÿ¹X–]»£nEˆ4H>&Td@‰Pè@€ˆTÑa1R‚G04ËePVxŸHÆ—Ì~|@   Ô,.-|ÀsÚr°>ŒW´ßr&ìªº'˜¥ZH}áŠDÂWCgˆ£Ä›*Ì8U#bË>(pnŠ((8Mó"ˆ`U”§Ê+©¢.,Á”Ì©$2™
+‘€   Ñ, ²¡Ë}§G‚Ì;(åbã «)®™‘©·‡­Ð/Úï[Ã¶¢EI2½!õt˜Làß2 ¬XÉCf¶.™£Å2dŸã­¦…4NÄ…éF@  &4]yñ¾M²]‚nï·I§Z[?Uµ^ÿsÓ9Ñ¬ëuáË< žxÌ_‡Y	ºhU³É€²#	—ˆŒ”8¨|e³§	¢d³²ÆW+téyA´lb   Ù,jD<ù ñûœê¥&™f$Hºø:#s"3k}½§àþ–Ð!ÕTü´È¢}Ä—¢`dX”ÈÊSxÀ¹sE„E„V8,Ñ“Œ#t‚Ÿ(¯¢¥&…U „@   ì,³ÁÀ±z¯…†¯;b;òì‰‰¶h'c·—Û	|ôÅ˜»ÎqeOÆÙº@£×ÁÇ¥FØaÑ§Ú4.ø˜¡ôÄÄ™,áÔ*¼IfIº®Q“´¡  4Þà]Ywx’c±§ÕÇâû*b¦by\‰Pì=ÓÓ=ð%oEô™ÄÜM1.Îábˆ7àâàúªÃŒt&lÃc"çDž:L\Á£ŽˆˆRhƒ«Ð\^Dh   Ã,T1žhÛ…¡B–Ç‹¬67²û™÷fjs#+Qÿvá»òÙÑ_H¶Ã¿*lq®Ê¶XdBËº@áÃ%	œ$@êÉ‹­ºô4‚Î®1àÎ2uH   Í,%áÍŠ5‘¯^	-‚ú‡êØdM¶Äƒa^\Îtöoóp)šÅèÕl÷"F(%(û£+xL™•yÓeÉ¢`XYr¢ix&"M4–™ ÌxTt‰`  4¤#x^EMÇO OUgŒ§1-K‘‰®ÎHj3µR–àCM„©’´éZQÆ!$¤$60ö ÈÇˆ"p: yÁÑaBÎ>,Ú„†œO!‚œD®€  
+4Ä„›$H/6¹æ’˜A‚D|á‹D³©V3¸¯v†W@îzV«C¼4ÐXýI!Î!µíÂÎ¦OšÇ‰
+,`<h¨xÛâ&Ë:X&©#'	šGBG
+DÆ¥Ð˜”   ´,/Â	|â*z±5ìaÑº|ˆˆÏ's¡mqþ~»ŒsÔ›¡l&›/©ò×ã«%Ûì³0qQ•^û"$ÈÄôU„H .@’éÞ:öeSi	” 0J   Ô,èP˜)3¡Î¬Å«³]î‚÷ûîƒr 5³Ô'æ¤t´^bûc}YÚ¬/´áòUú8ã…†"(ËÉ‹µ4]ÂÅÞhH’hDhyH }|¦éS©€   ×4ób…Úâ²5–üMú‰dp¶´G¹þÏC4íîfn“«[)6c4äø¼|ÝO™ÂËd*6ü
+˜à±µŒ´<Z¨±fÊ@HÑ”DÞfPY’	n6êÓ4…ap   ×4AÓP¢æ*¡¤ˆ±¥(\#›œ¥¸ÆˆÒ”§î#i­¡„põlü%‚z
+pÊK!4"éa9ÀeÙ„.L Tf˜ÓâÄÇ8t˜›o
+Ÿ]JYøcè’    k4dI{	;*©ˆ›¨nÂ…¨&!Êuì¼WuOé1 ìÄà'ñ!‹â²æ0ÕmqWŽé,LÝ²kˆJf0 Üá‚-Œ™A°›‚]m„U8U7ŸU™™pºÀ   ›4›‘£Ã‡§“[CÈ4aŒ´ÑŸõ¥ÿýJ7–ˆ¢Tê3ÞUY­pÒD¨ôqC¨ÚŒÁY•2QP€¢™4x›%	.EDDNfI‰u„À   Ã4
+T'yv”ø»'Œ‘ÙÊŠjý›ðµ¤ÿ¦7çn’Ï»ö^ä!y4‰ÖÒ&Ü½%í‰mX\`ÔßQbî4}²«Ø6TUr*¦DÙeW¼\ÒDÅâAj€   s4ãr…S Wp‹>H<î‰¼Ý-ë×äb0âV—KÓÇ¼;c-Ä¡Ú:æÃÓ¥²ppÆLPÚ°uÔD	›*@©rQíõ2]GP¶IŸ@Ë°   t,D`XêÁIîL9Š°«³C"j‘{á1ð,aº#zßø×¶˜úÃrQ[ÄÊÙyÇ´@óÆóë´¨âÒŠÄ]>Û‚fGÌWt™fÍ'ÊP‚ILu7M€   Ÿ,*Q!ë€×X»D‰2ÿ†ËœT\Î´2®L¥”û¸@V/}¢^±Hvv6sÒ	÷:–i¼<0`g¬\©"AU‹¶ÄTYuM:MK‘(ê$TLLbíÚ$   s4‡û8i	Fü—:·É`ÆL‘ûÂ{ùÜök–ÀdêLnÑy££;à(´µ}ŸìHSªß¯Lm<œ¹±wŒ%&Š17* léæ‘Øu$]>ÔˆìÐ‰€   ‘4•Ž¾~>ñHÉø‚?.ì³Û¿C%äæOÝüæ¹Œ'°J££ð »Ä¬öOyÁŒ©J«X'i‘4T¸DLm—èm˜‰¦—}1…B‚NKY“ÈÍ©ël,xœ€ÿ×    ~4³’h”³†g×-ãÊq€LÝ&&¶ÁmˆH—ž™)1ùâ	duþ…Íxm¼„ÊjO{$-~$¼áœ®<àµÃÉd×%ãÃËQ£N0!ì`6 •-á©ãÖ   p,!ÿ‹0Pè ‡•,’E&'¼¯0ŸI|unŽÄéŠBF¡>ÆÈNeØ—¦C3ü–'Õ´è!>l”³<ä@!´·F F ”0{¤0jÒ‘b¬0ç    k4s‡J“¤êdKM
+ûª½ŸÁÚükŽu÷´2ñÎÚó'Ð†ÌÄŠOîRbXÐÆ›¥•QDˆ$`7õ–[CŒ"!Šp€ƒÎS*    5,.ÑŽ4ü‡Ø%¶ëãA¿„â.:¹•;šÄfâoßâÚR7ŠüšÞgEv3C÷[¤YAPJÍRôÐ,@ƒ—9ÒØ)îjH)i(P   (4W ¹Zjué¶ZåÉöj™˜ÃÊh)0Æ“Qv¼÷:.ñ§™S1,þUC—×TR2žÖa"Óˆ…åt5î)qa¥E´4"%jD²…&‡<ô„
+RÊ,   M4áy|Ç™É†^´`¯ëBv—µjðœñ`R¬Ú®VtÌjx¥Ý~Àør:§èD{@d9Þ«l:1ªµ!ÓÓæ´]Ó…Žž’ ½ÈDø‘Z'ÄLÉŒûÒ€   ­4ñIV©- L¥dn_C+ÛÁ0ý=Ì~Ýs&áŽ´>~NËÐÂädœn&)÷wb6”Ñ("Œ,3Òq©Š'.¬¸ÚpÛT‹?pE.ÆÇÌN“L"äÚ²ã	­iÀ   †4¶9)
+†£Ó˜1ûtýüÛæ˜N`¼BTüvtŒa‘”«±>\O…PT;õ_ú‘cV}ÑêæœŒ–ôOá$¤
+>Å+¸áÁçÊEÉ]C¨J¨¢Ñ„@   4	J°>™î@Ñ
+µØL¶+˜V•Ò­Åq¨T¤3j`³·êÈ5Zd’K<Eï“zjž,’c¤i*„²ÕFòÜ_P²ï.QƒË0*‹gÚy¯š8\ª„b‡e    '4Cty´²c_zÁ™Ç4S,«‰F†(íHõç0”Ò%W¼ˆg‘^Fh¸Ø ò@ø_–ÂÅ9¹!?˜/;U“(?6ÑÆ^›CõÇG	Âu[,Ä‰Df,¡‚    #4¥e½"ˆ±>Pº;5„‰¿ˆP-Uc¹wµ:ƒáØ»oVJsªÕØ¢¨Õ&¼ÕdÝ6ºhyæ2öš43(_'dJœOY1séX â’C>@Ñ0   ,4åÎ´«ª6ŽM*4¿µ E“@„OÕÞö®ðÅY´¦3Ç3µ.ÐÕ‰QÒÓÊHS,rà™
+2††Žï.HÉ4©GJ¦•Ò(˜$*ÃÂe¯TŠfÌã×N€   4°*­gÚ—&RÌ$WÎQù—E4ü”™+zkñªnˆFÓ+£·H¼—”ÈÒ¿‘&'í¤àÒ(¢º“lò­žTä¡Ôi0,“„œ(PŠ'2I‹     4(º…P—@áŸäžý>b|5BáÚª^’lo]Æ×Ý› cÙ²˜ B¨¬ñ¡Z¸Ý¤)ØqÛ§ M™¹¾}ÂzY(H™º%•dÚYB¤Û.ÁgUQF—ß     4
+#T„éØ,­l#Mj”zG.ÍÊDc‚rSéåšÍ˜É™àðuâ8D 5Äˆ&JàÙSô€`¬l®ó”‘XãD<K<3Ì^     4‘krÆSrÊEŒY²½óžàâ¸©V»A.Fcné­¶ÅGj£«gÿ…‡¾q­NROd ÈÅâƒrÑg´,a·ª¸° •°YK*ÊB%–&‰qÒ¨¨8     4$ÅET`2'©’z¶“bD¥uhÇŒÓ|G¶f¹|M`IkT#sÁS^'K%ì'†é±%òs"€ñTJ>¹UW¶Òå‚¨ï.Á1g­Pá›å‡†¨¢2@   4wæ…bh ð¦”Ñ)tÜÑ§ãô‡Ç ˜ŒÖ”&Ñ>	ªgë¶nÇb¤Ã}˜¨‘¨]5‚ã-vt£È'|ÓñÒŸ>‘ešqc¯.æêŒ@4†P    4´Ýër^k:$|Ý2¨‹ã×H&R4zO²¿DVAt™HîØDÂÅÍVa FaÁ}ëB_‘Æ3"ë‘7ëÅkš:‚5›²ñFŸD±ÒõŸ_a‹8H¸    , I@ùÏBV è B·&$9Ú.+GþjæF²k£È„P¡}êiÐŒèj}’ÒD=ýïY¤L‡	Óri±Ä(¾4Í™áÁÉüI+‰ˆšf¹ÓwÒŒ8˜Ä×Ð    4	,)q”§	"‡¢/¨F„AÅfþ›g’5smg>˜D‘;F€PJ˜Ö¦IŽœ¸’ôj”®7érnQ:‹îÜ$òƒÂv…IÛ<¬Â¤H>6üÂ?Šå`    ,I+BÉ œ¨j0`ˆ8|L’)
+ä%‘UÊ	?e!×Z0º¢|8÷Ã¢T³É™@Ÿ¸	™’o;ñÅ¸i°uëì¦Á×•CÓo&|´$´€ÒL(h   4–Q_Úe[…IV.—2g¡à½Ãº`ÑÊÄÓ‰ÛpjÝ[ÞVÝ,0bx{³ÁL®ÐH¡n~Z©¥Ð%7N9á·Ê‰”˜¬XªÃ(.$¬HÑ‰DÍjE‘œdtØ   4	H¤X®±3|A¤;WI Ü«Ä%î¿›?:SIHT ªE´VZlõ>Õð \„{ÃbU¤P1Ð+™dY8£T¼~¸`Æ¨FI‹ÊDã	Ø(3¬0   C4(Uå$×*%4]¼¸¸™u´ðì¨í"¢‘ Žáàf`Dv\JD!ÉŒj—°I¦è¨¨•ãê-QT«ÃvÁ„Ù*¢p¹‚í”‚E&NÍb<*U@"“Ã¥#.    4è.ÁÂ“Ó¶å2…ZìiÝÎÉk$ÉŒŠµùˆ„#8º*N•5¹¾l¥_VÌâ2e„œ‰¥L)eâ
+f³‚NH]2B¤Ô0ÉR“³™     4wBfnUO&•#úgo’ôƒd-šÄ‘Qùa_!…‚` m±gZat0w­Mš#T‡º¡–3]CMå¡Ð¶Á•/VD›¶\^™¥T–";B+÷@    4Yˆ?ãêªäÛ¼ú¦ðH1ß$¨­n‚B9ö7•®þ¢ô¤2Þ›‰³ùz/^ºª#pBšÈ»2‘øÙ/MI¤‡kÍ”¶ Ú•Åo"d©’$Ì03‹ˆ     ,¨°þJb
+8ÁQb¤Ü·ƒH¯Ø5TR*Î[ÅÊ
+
+Iíš‚$îÈÔ*bfô¢†r¨­±LÅ"Ia>Ôt^e4Ó|û‘‘Ôû2BÐ    4«i*B1öunXÜÙZø8aøO‹¢â1'ü0š¹)T0-qrráõTØÝe©ŠÌ·‘±érÎ)¦“@’E–¢ÚÅZ!ú¿¾£„‰£Ü"}‘‘©C£âŽÙ3ã€   M4Ë®o
+›Œ
+Ði¯…³S±‡¥u£Ó—×4bðÊŒüøT~\÷…Äá3ÒLé¹WPI)(BLÅåž£2‚lQÖGµÌQuµó‹üáÅVQÓRƒ#    %4.;$­‘yFÒÃè©œÒ•9IÈÖ––?$BˆÍe8Ü€€K—¥”ùÒ÷šWgKPeßÛîQ<¦ýy:Á.nç³—`cÉ‚\lQ$Aá°I@éâ€    4$‘"]k)åÜ¢o´ °[YHÃÿkrj×>É˜Ä5ñ‡iOŸ”àh¬€Í‡¢fè¶±¤‰ã2b‚1V x'x»T–öPhßÂëË“—R$¬“Æ´ãe    4I“Ñ+ˆbÔq$-b`‰À„\®&zšfÓS:^«å¤L®GÌgTÕ©¸LZ©
+kÞ%@NúKÊfK<A´5PXßyÂÝ|QÎ°ÕÕ5I´$   '4dË»I&ª„’eGî'.'.-*L!Šý|”D-1F¤<B]"›È††²Ýj§»±L•¶.ã†¨Š1˜ÒÏãò¾°Åcq34‰›/X‰Øù³’„™œœ¡Brð   $4º‘õ•‹¹ú¬Î””n’Ž6ýñ;")&6ŸYÉlÙ'4£µ«	9jóò{&ñÚ¶×™%ˆ•¬¹«’¸F3Aìé‹®õaU‹“™Q™‰¶xØ   
+4Q¢:q~‹HÄ„>1‹ãZ;,j-Šº‹ 4í³$p¥–ŠöÒ¢Ž¨f(žæòqI}tSNÌE’Ùiš+´°Ž-Ž·xo‡Œ8…' íñI³fÆƒP‚À   4&“y‡ª¿uS%4›††}9p‘¢“¤¤þg8º.dÈÍÂòI‘&ª«Ó~Ò}'Iì
+ì†ÜT,Ÿ“S¦hÞåŒ¸Ù`„±‹‡E&³"€   $4÷ö*Ed}Œ©fø´,?Q}Ž=¡‚y†,Â¨“b˜‚t¸‹ò"7UçÉZ~™¶žåEÕ)3bQD_Å’©3Ò¬ŸWí%
+—‰®IÁšxØ¨   4Ë>&FmºÅsOüV`8'/û†‹õœ>0 7¶2ÙtÑ0›>1•bùz`÷Î‘—kßJ¡´ÀraqùãyH.j«–ó–5Ö0krjµbdl$GÔBdJŠ    *4Õu8“”I¤í²Dìº–§Eèž#¡ÖíM®µÁ^L-Ô„,•NAQ$YjÁaüKR\ÐX¼Ç‚%øµ_Á)ïÕP}Gˆ‚ö„”—BjdŒ”3‰xt   >4äA½2Ín¨ò¥I˜ˆfAÆ=jq¯~@h5)»ES®›B±_XÀÉD:Î"~eãjØÍÊF80½ºdœ¸“øjª„8K„E
+L]‚b    #4ª(†?>j‰&%BQU.^ Ÿœ Ìš\Ï;uEFmB	Œ4Ý”µJUÑË¥çQ“s‡/•Cj¥¥•õµò®–þÄ4`6‚ÐÚÄ¡4ì©lG"AŠ˜YR†    (4æ˜úÉ
+Ã¤	É5Jprû1A[Š<\P!qãçf4¡gèPi™ZìQÔI$ï,W-y)rÕ-%];…	aJ®¤æ×g\œ²~‰1Èx¤ña `"   ,4óéa"|)ê½—z&FÌ‹Ñ×HÐIÁ¸ÃÑ7i¤uhD]U££·„R1àŠe£lî!8tíÑ™%ÄNêFÈ'y»$k’3Ïì CXàµ@@/´$”òÌV`v   <4dUÔÙsT‰ÖPéªKù>Ýt¤^ä¡9á!HèœÅÖ$$B¨6šÚGËLD\îL¹ÞcAV[¬¥ÐÄÅÚsZzòNˆ„’Â°È=p>¸FeÁ
+¡0¥e‘‹@   =4‘7"Ý¡+CóæÎÔ$-§D"#nîo‘°ùºS>T¹´&RîyºSb›Ö Åá!@è­¦KÌD·y|<;®P¼¯|¼Œ°öûáÃ1Q	seÇ<}àŒ   (4øY)¡
+æè³à€#&ª„ Î{0)>rh¼T¼˜Ó¤]kf+Áõ*—@ÜÊÇU—OÎÏ$ÒZ‘TUcSº´û9R
+	ˆ…åõÂJ°òXtÈ¢L0   14S„†»åõý\µu‘"¥ûÉ¸Iò0ÿC+ø5Íº½‚Œ41&0­o¨îÎµØº¼Dé³ï)3LhÄŽcˆÝ×Äj(ª
+xDFPÕÉ*×“Š“ƒËŽ    -4¹>^¬‚+H•È\•%‹ù^È¡FQÄä“Bp¼ÌHÕ{©uEæI´Ô/ì’Ñ…Ü¶‹ÒJäDj2°ÝÒÞ¥×Åv$†ÙæmÛ3h|­ñØ‚Á!ù©hV   :4^„ÌmüÁ”¬JÔ³å5ï‘ÈoF>±:LL|Œ pßãÏ— Y-è4WÔ¨¸A“JÉDí„ÂaGÆjDLsYUm¬§y¾Ö³d ‰’`   4WÑÂºüñ{µ|¸=hMƒˆ{
+œðJb°Íž7.a,
+ ùä,†…Tyoˆ™1É¾&‘Ñ–Á†fjŒV>wTÓ*r™¥‰Õd¬£
+²I    F4q7)ÒôBAKI:
+B¢=‹ÇIÅ„bI_ztIÈI†ÎÅQ@*¾®ý“…ßa—7>p€R$¸›IÆƒþÈù
+72	Z8Ôñ>Kôw”c(»S
+9tH   -,¬,«á©­~¥uˆßË IY €åŒÙÍ‰¤ÑÒ)T¸òâ"óXÔ©5×r“¹>3=+HŸX'…I{ËÕí¾lŸ)öø±>oN›Dclt4   )4¯`Í±Š¢b
+Ì%^£¼ÊÄ	mdî³2dn,2®6X¢—ÂmEØE"éU2£q·!E·^âQ)jU†ÐxJ?ÿ†WcGÌIv0¦ˆBFBFš6’´8   L4Ø^ wŠï§e»«ú×Sq¢®‰®¼ªjÄ™¦ŒV6h«TÊ“l‹.á±AeêÄŒ9UZt¼¤rRe,*Iø¦	›·Ž |ZªkTPËËsÅ–"jIˆž    T4%€!\Š=‰Û÷½zàÙIÀ¸vpeø’CXh&"*bPúsKz<ùò“GRf}SjJxk.M_’­Z0~·´†%Çù–-Ö¬Ð¡ª
+þ*81¢–Å    a4ë¡I0zgóÚ‹“Ð¸¥4éT$ÜaûN0µq”
+£p$¥ dJX¡”Èß\Iü„…•®Z<R0²ÞAsB4µ¹ÀÜúaúæ½cŸ©#NÁŠe0¡"zŒpÄ™p   84oxŽB“Eq²KnÖPÅ"f“FMCÊ‹BcT«Î‹ºL@Æd:‰$f~QòÂ5ÌŒ^m!M°zu»÷È\#S°Ÿ«‘S#\[;ÁfSÊD«C|¡¡`   94¬J¯j‘­Â’Œešu$WH¢s/”cØ²Â
+Œ°Ê’Í‘	0]¤"L‡˜­­×”4Ò­Š)ž/Œé‚ZÈ/ee…3|nd#á£—i1eð¤a+¦¢E†€   84Sº6	Õ
+È¨i>³?DE•¤@Šµ¢&€ÞP8“CŠÕh¹#íVeZiÿ´âj \“Ò”¯2Â’ÿ—š³¹¿%@ýÔ.Õ3ªõ9&åfd ¢ƒà   -4ŠZ/¡«ãâi+ _òfÔŽ&$ÓZ±ÀÄ›:b}b&Éž\ªn	¦áã=I¼ŽÌ?X™,&Ú(!O<âÚf(¬IÊÞè¶__9¸ë«ŒPÒ¢    _4êí‰¶…¶A–·:¤)y©¸ù¨6•!XQU 2É@ê•ÅP}³ËL=Ù–qqÇ$ù¢ô^¨1pÄìevÍEŸ‘Å—´µy¶å|Cˆƒgwj£oŒÁ×N    =4¢äœÑ
+¨v+H­tsõ¸mj¶Ð»£),L‰¶“"p™¦áBvÃµâl
+œÂˆ‘J"ãS¾œô£1ºÂ4]Ãlkh2w„ô!"@!2®ÐÃ,    14Ó·8àDüÃò4…„õ¥•)ÆŒ“&XI¦Œèó¸Ž YÂ!Æ-Â$[†æ«$&–Þ0ËÙ?3¯!/•ØD
+×[¾¹ÂBlçç=jŠ³ Þe¤L&:&L    [4d¨”š!rY]\Wðì‰‰SCT˜ÎGDPûD‹t€ù#bj„B%fH”OýÅDËäÉ‡­~Ö¢37U›ºÈ%P&ª7Õê<YÍ	
+Îñ51X   <4eÃ¸g¡4ýQœÓ¦!¨„¹¡6­¾hy;‡‰™‚›K”A°É+B‚Iàò»)@\©1)qNÌ°Q™¨‹|.”Ý¢w+ùI[Æ™ÉÕÄ£Y².ó:—Åï`   I4µ2äD#VÛfôÆl $W á´nœ*8Z4€ÃÔ”`U©ö©…ˆ/!x(ZãEß!šQ/œ§1ÞjÀÅ€ìŠö;Wâº`»Åðvñ$ëSRávÆà“4€   34
+W ¨ÜI‘/pï,w'$`DñB(Ï™4UA’hY!tšB(D‚®‘*>RFË³Î±·iØd+¾½øØkÀŒTÁ9¶•‡-”0è¥”˜‡^˜¢åî€   94þAÌ¯Ô4‡…)Újªµ%§…Ø@Â‘1tB$÷ŒY­áUäH– »/.RTóëˆ6.qDÕÓ©£4Ùø·cÒ«™­\ž˜+™ýî¹«ys²Ú‹¬3&“8   I4­šÉ‘Ê‡Kgó?=ŽûüpUæÃ)[Š;nXˆ^s¢/hìZ<¼ÃPÐNe1'è"…>!d÷ôw]µ\9{€G³Ï&n…|ƒŒNVBñ¸   s4Ø‚†êXì÷hùû(ÆÌª“jCH<ÓÂF†K‰cÏ26}‚á$ß¡(Ð’ö“LÔœ„R¤tVA1Ÿˆ¯‘mmxv‰ÌÆ0vnˆn:¨C[ÊÔìÚjŒDê    g4ôÑœuÞó	:ªb±9f[	¢(¯¥FE’ˆTòiÄÈºØÁ¡Ahò;‹¥,Ù³e…WÀÙrx†Â“<$íKÉ…¼-À†¯y”¿V]›åã*û¥¥ß´Îäà   b4»‰ŸÅ§Årcá–g7_²UKKI¡Ôò	Œº‚Îº´iÔY:¤»¾*Œ!0Y]>fÑ€”Ç~_R
+[gÊÙošÓœÙ7‹fjj]<ˆÎ~béÑ.   Ÿ4íu­üj‰ãDRá½í˜ü„ÀË‡†Æ9”Ÿ{rgEÄ¥DÉH\1"@Øz]pÎtªÔNW”Ì“ÌîÆ¨±j¸R6!¯CzýÊ^gŽ ¤DOÖÉ|YaYÌ;    r4é"Ž„?Ë7dåÏãÅ•vŒ!üÙéyâÎŒ–(2-Ÿxlm2O’>>¡‡Ežr"rø‘TÔYaÖ|¾ÔÄ¢¥ôÌÕÜ•§çxVS‹~ÖÌÄMšTNDØtdD—    |4x¡Ú[àæÜuE¸e‰Ü
+–FñÂDJÙSÏ›:(¹ç_“2P³§Èß!.Az«ý6åK†ønÏø"ä†íÄæËÏÍ¬Íf¥W!H¤â¨A“ÄÀ   _4A‘Ë:_†õùu¦|D`Ä\TšÕBÉ‹4ÔÆÂ‰i³kKˆi1Ì¾aiR¿‹™Rã¤äÕîÐÌì&f¦HHkå|d+
+fý8«±<xðÛtSÖ˜ÙW;    j4y"ÁÎý'P¦VIÑÙ6,L$qbƒÉ
+²¬Ág<„Š	KWbÑ´Þ(¶N…’¦Ÿ‰îà¹€P/·É þ2EbKŸ‹+¢Ä²
+ãFJ0H¢H@    ‹4cÖª'ãHWæƒ™’ôN>²§Š "Da!‚Ó.qÂƒ¯v04ìª‚Bç#…s,Ù:Å×vVlÔ@ÿ‚2€Ÿ s¾B{©½ÈJH‹H´3PÍÃÄæd©b€   i,.ªäïÔW(Ûu¦2ûÐ&x|P°XÃÌ ’Ñ‘3X¶Ð‰Ö­SóíË”3ø6–ý*é2Ë¶éÿá¹A{Ø,Jïeäø’)Ot³|‰>Æ­Š5+Â,   “4øôO•…{ÖR™RƒYîEƒÆ=Xd¨MÒ"pâãêÔh"¸â…N¬IAt)¤e‹ÆËáUi§2½Y
+ÞÍÜ)ÀRµ”,éµm16[“†ž\«6   š4	Ëw:Vï8÷ƒ}¦îÊûf X¨†	
+ PdfK(l&Qv•(•Gytî†ÉŠÒ"ñ/ÖÌlÈ>Äý'nIœöï5ñjGã¿fÊNöF¡þ“Ë    j4±Š=‹d¿¬É‚”KÎ2,R m2$Í¾0$3f/‡’ò(šÁµ2Pi¯Ä $*ÃøUmiqmÆÑi’<›Ôž´kæ5ÓnK{hsÔdmÙÿçÜk4|Ø   €4V°B€Cñ?Q~šå²:|¡ÅØQv"¥Òš(é°“í¢<•ó*È­r†Sh‚Á	ºŒ›T|´k ŽhÝ´tòõœ	¿H¦GÒthŒ1|   †4íSBTmŒ`•›¤lá=…•b (¢â"%B*†Æm±Dbl‘,ð\ÂGQy0È“¹®ŠÎ”^‘ùtæ½D|çÛþÊšÞf™Øñ)ìÆ¸”ÂPNÒ%gJL\ÒN    ¦4lñ#ŠUŒàR¼ËJ>V´$»DH<<`ÀXíÑž&T¸¡	1²…F•œD»DB"•Ý™báY÷¿(ˆÞÊ‘ß8×]£KÌ,KñQ¹-Ñ›Âe¸…u*#14–´   ,jå\="@œÒëðÄfoF ¡
+\hÏ
+”a¢ä‹8ét¨ÉÄ?T<²ÛÒ;ÙÖ¥h*îIàÐ|»…H“OnØÈÑh¶#£—›(x   œ4—çV†«x/iqb‘JØ,0XÉÐ“‹NŸFXqÃcã1 ]ÈÑ’jO¢Y¨(Îã!²L©J¨þ5|:®7œRÂ÷*P”Óð­Š¾È®ù~W¹±c3n‘`   ¹4NlŽW9ÌžyZ7Å\¼‡|ly‚0qX.˜Î8ZˆM°Ùã­Á#‘’À¡‚Ã€
+Œr­¸g…2žÊ¶‚:—·ñ¹ž,óGgkKMÉ‘çø˜ÛÉÄ    ¹4:çÍi±L©Þ)15Âõ…–@&(. ¸¸Ã.0LÈ4£Îˆ>”a)`ÉºÃÁSdä^‰1BóPÍd*Ò«ö.ò#G9*ßJTNc"7$	—ûgå"å    Ñ4 ®ŒÈD:¥©Ui$÷ô¸´iPùò"`áX,2”@t„(‚&ÍmÖ“7v|Þ„^[BptÕR’$F3Â´åoÐ½¦÷s/G ÜÜ(B§hÓ}Ê'pTi=   ‰4¶WS›}Ÿ¿-s‚kéµ)ÓK‰ÚNð°€ÀÔ¨$xYAT­’vÀ‘SNªœÈÃl[hQ7¶%2ìþOr¹ná<(]ßz’Æ×7Ò= cAá9š$õÐ   s,>÷Æ]m Š™^	W¸‹ì\4$0à‘#|À²”F<AGF¾eq1JƒäÅõÎ½Tä¤
+**â(‚f—Ú‹äÊ¬ù]Ä‰µÆ.wÏùœ,÷    ¢4sá¾dkïŠ¬¥;Gñ„U Y&#plð¸ˆÃÏ‡	¾<”L™äCÇˆ¬<bÉÐ`dÄÊ_¬™dæ©ÆÁ
+»b9ß&â{8#…yš"W÷ì±Ÿ°ÌéIqºi’À   ¨46w:Õ‘ˆ±’yœ-ÜUGDÂhFH¡&p @fÄJ8P`ÉòBK‚Š("øhž"‚‚m	£q/œfoêk[öËÊìN…J·nB×4äWÔtb¼   ‹4£æ^ÑõÔåDû{É‰‹;,(%&pž(ÐàÂ™2Eð‚Ä]ˆ›/ \@Â¶DWYù%Ïö|°œB$²—?dt€d6Ó*Õô¥QDŒóUÜ    Î4ž¬_ºûUðNÖ¿¯&¤K«(\\T@T ÈÄØ
+>d4,pã¡G6Pi`Ó>„\¸ ËYPnhÑ\¬×?É‹`÷!ålH¦VR©¾¬P90ºII    Ï4B’)ˆkPjŽurÏK'7Š˜`Hñó¡3â–¨P¼(¸€‘ÂA£LštqÖ!gö2xšQâ„,4€ÝàèŸ#;Ít—Ö$êm/’{GêÕ4LC£ñwËNÉczÐ   ‹4:«:~®þæßj\æŠÛì`¡w…&dàé#8R@b€ˆ¢„_.(é&œ>ºVGE
+U6“­±&6¾ÜBÁšQ›Äƒ™”üg1GÕ©gy™EdÓBgPÈh   ª4æ#óÂû™ÃþpGl5­Ù3dŠ› L*TD 7k„¶xùWß‰FTª¦Ò."F$vÉRˆâ4($SÝœ\Foèë£S”tµ¨É¬¨‚õØDc*„@   Ç4É}¿u;AYøÁG1¯é2ãiŽ
+I‚G„´¸j˜¹£Cãåˆ$2dÊ!€a‰1†™|ƒbòÄ¸HôcÊ6©ò=^­ì¤E"XÌbÃ§û¹ˆeÙ”2A°   Æ4ºÆ¥|¤R§ô¶kÈó`p€U ù£#dF((H*.¼øq9”"&EÂd8<ÛÑA3$¸`ËŽ©7·E|¾z1„ÆŸÄ±«ZoÙæ!Û'·‘#ê±©t&Mã…    4âÝÔð3Þßgm>Æm‹¡äž	œ0ˆÛ¡Ò²â¸p»øm±â¢$Q–¶±RÅÔ8‰i¢y¢UtzÿòvCÿl¯ý,ÙüÖæ„ñ3æ«,;ö÷    °4ËQÉ˜ãªüÙó’/ð"2ÌÉÓBà±1Ê‹">
+¢irCãa†‹¾@@H4y÷{
+«E\æ®á!J:Ñ»ö–òÞûßÄ¢Ô·œŸ8ô÷·1:´ÿ¯€   ¹4:©×4’ÏÅ²Òõñ¬­<lTØXú#bF‡†d 0hTP\AÁt±³Ê
+ARÄ¤A1“cl¢$îî¼ÅÄ9¡ZÇ†hßêµž%ûâ¬õ¬âCB™sÛD&éÒ+€   Á4	HÊÿ¹]ÄwVÕeÇJºŠ¨8(&Bd.Œh2¼Pg®’V<@àu…E‚-ºTù"EÇÁ7œ©³_ÓDìÔÎ¸~·þHÈ±Öw+õFg‰"Y©,\„¾9€   º4ŽÔÒžè
+mÿ7±¡LA·ï.y‚Â ©F&MÉ‘ÂDÏ4}É“$&Š%—–A’ª¾ˆÈîÖØøjOòvfÆaJsã“rãáN‰TºÛÂ²=^    ®4™Óz?hï¢š7Ñ4Äh–LËÁd†K£a1qUI‚¤Ïº.È‰aT
+…Ÿül`$½âM	*·óY]IØ”ÃlzŸØÞ\Í{Ý{uÆ¢™V!¦§…ÂÂI    ›4–üý-s­Ýå;q¬¨äLÙ†Iª¬Tû“4(Y¢á(„„VmbZi)q‘ÄRôÂŽà/‰ ÍŸn>s½26€ˆŠ*läÃ5§”DÉº Ð   Â4Ø¦jÝ»å'Ñ|µOŸ„_>@\mÅÆDT¤0‘1aE¦Ÿ,&TÉ!ôÉhTÅaQPŠ©2uJÄLñ«ª¹?__ØÐÍï2zþR›wÑùÕPJt€   Ã4e¹SýNRí¯¦,:!ƒ\Ÿ006‡‚¦\€ÆZd`:uJ!1ÔiˆŒ˜i‚e[š(Ld¢‰I”OÕ¦úm·?DRÏÂÛÃ²²4ýz–B;ª G+GJL›6Ÿ    ¨4ØÉA\Ð™k¸"’–½Lð³fDÞVù÷ÊŒ‚‚cP(@x2ÅÇÙ*q:¬%piäVCŠc_ºåjôCþðnés<TáïèeZ‡/S9$¡	R»@    4Òýii4†sßO¨aùM®@ xD‰@±nƒC4ã¤Æ—¨&Tù’!–T‘fdÆ	:‰w6‡¢§°Ñ1…NÒ¨"Od39#Q™2ÝUÀÆJÁ.    ¿4qºÖûßÍ¹ÿM™ß)OÇ”,(°££‰ÈAB¥É¼"ÉsÁ&Ò™:ºÏ"4uvO¼ÒéìDmû#'lí4»ç\S/3Ž]Zà·Ù×¾H¬¾=¢À   ¤4àLß>½!Þ*	õH¦æ÷RhM1÷’<NÄ]°>±ÅÉ…Œ0P±ÑÕÌ,‡Ï‹›SQUû06lßP§ÚËïÎRŸkí[UJÖØ¯ßµwCºŸrgZVÀ   Ä4×Ñ~ŽË;¬Ÿt‘ð±±cAÆ’“ÄSù‡N	&4p¸UsS$…Âdp&dMrä\C:AOrÐ¾†ÿ§Rk;77½¶²²GjnCÍuuvö„€   ¨4ªù^(‹nµ<›åÚöL¬Ë!a%Â­30¸™ç_™2*ñ"‡ °‘ ™õõ¨ñuø¶ßºÐ±¥K•¸ÖN;Yyy;,Há†…+ðÁÑ»F‰    Ú4'¤ÈKf§uÿî•Ó[ÿÌ›–Ï‚IÖ
+…Ÿ01ó¦K*:0ÈøÈÓÀ‰oÃ)!ÂT™A™`§‚syÈçz”–âVò7#æ“|–ÈSG¤FU*b€   Ž4ãÿYZ‹%·Ï|_¡ÙGŽ—"˜qWC&›®1u‹8Á¢J¾p±Ç‰¯&ë÷>úÖÚKÖ@d£)¨faQ^Øúè‘u8Üp'W`$ÏI §(  '4¢Øò¬†—öÐ®8\¦^˜±XAð@x"¨\D	”èíi©ijÓB‡‹ÎŒHÊ
+™lÈÜ™'ÌD±
+y¦ LB» R¥iL)ÊÌÄ|ÆkŠ!H…´æ$»šAQ…·|   ‘4«aâó¸-zMjKF7+:8R]áqå‡FáÁaÕ4Á×WpP&ë	¦Ra†qºËs ¢ezÅJ]É_fsiôÂ°ô–´Óà¢ÒCtÍ)Ð   ¸4£­ègw­¨î¸Æ……s|ØÁ’'FÐÉÛn.84isL	2X(š“C¥•¾Óî?P¸ÈbA!‹B]½ríò×<—¡®—2¹¤Q(‘pZmÐ€   Ö4”ö[ïUæ+…v÷­ J¡dìgž.P¸"a«Ã		*8hˆ¡A¶lú³b‰60,@™"ÉšV…qæî‘12¨›.ÞrÈ\>ÚDM®||[b4>±Î•Á)‘   ß4Òí©[sCïèséb÷Š?>2.8yap©7|lñ1r§B§E\LÈ¨ª££N$:" °Ùb±v„,Ñ®+­sZ7ñ±Ìß§º-_íÝÕ(×5ÖuMœÀ  4IiHrŒ÷šxÔÝÑ¶HÈD(6	0x›çÄ#"¦åæÍÏQ	\˜˜!ÞüèøŒ˜zÉUÃ/½’@—$á*å¥$(šÅà1+5­_Òžû`%†µD‚à   ¼4»’diéÄ¥Š)èJBóÔÞf`(HH‚Bƒç•Þxˆ©åFO¤.M!r…Šª”¨Pˆ‚nU2Q¼evÀ‡Ææ|Ìn:iªsÒí—ÅŸ,75•XÈIp   Ä4×ÌWÆ¿ßº¹¬öù|°)|`Ê­(a±°xPQj›"<Mâ¤Ô,u„š82áv‘x¡:
+”}BíDå1ñÓâÈ'¾R˜ƒíßÊ(Ë8x   ·49åÏ+±ŽÅ,ï®Šˆx$™“†ÆšD@i&lùÄŸ`qz£%Œ8,ÒqâåUù¦+Ž,.BˆCý_«jáû5äª')ÎoØ¢_íé~ÃCm»%À   Ì4sˆ•·*^ÿ¡ß¨‘&0¨™ YFƒã.ËŒ@Pm™"XáÑDÔp¨ã…çO¡ñEKJWP+àî_Ms%U‹R·ä„ïå)——/ïVÚþ
+bB‰    Ù4ÉcC/Ä&kSvõRõ»#d“e"MžtPXh¨ma€‹E^46¸Éd(ˆ£+H&ðØÅ=«ü#ö4$;ÇiYŽR½¦“”9jê-+’@  4Ç¶Ä•¿š‰m•þ×•Ô„â*†ÉŒEáã¦†L\˜À™·„B¥DL„Î'5TÛ ˜M(ªùÅ¬Tf(Éž«)gÙMÖ‘©ô÷[T‘¶#=XÍæ-‰‘"`Ð   ÿ4
+ûVžÔó%ZO'%}rÝAu„ÍÇ‡KŒ…Ä„DÆHàl8Ì˜Q!1ä‰ÉT6$\"qñ”óM‚#Nz *=•ù~ÊKãjwšÓx19‚ó,‰Éðoò%ç#cÖÄ  4ôÔæ~ÍâgC²^¯ í†ÇŽËBÅ	Š	¢\6M(°ò'ÇfV‰?Ty74e§Ü¨7w.äüÀKi«·jP¹ÆýÝ¥ˆ‚˜‚
+O€  (4MU×‘™ßIÖ	RÔ1ƒe¯:X60.4p8‘±1ñ¶„#äDL0:$8,,±°>›Œ:S9ðª‚•ûšÿþc‘›À5Ö“¿ú3…IœèpBlÎ "  4§õy}©Lþ§—ö©2?l&RH&œ<8`.áÑá&ÆŠ™	J¦x"30<L4¨»LMY™ &€½QÙ®‹ÿ+à´ö'ì×êoÑ“ßÂæætÑ[€   ï4‰énŽ7º­Žåe½!ŠÒB( 4haã!qñ‡F\ 2P°‚ãåÎBL2@ò!ÅÉ¢2meØO‹£U#É 
+ÈþKyL}Âv[*òÝdÔÁn*`u¾¥°„   4±àüÏ·½~…©¼>o}dÚ&`(.26XldaSÃfK2x\UÑÓ¥O>20&-"dÇfOÚv’'„Åþ+î)Õ	~#»žïQš*„êði¥Y€   ë4¿PÌ9,Õ»‘
+˜•¸-dHlà€ÙQ1¡±‡Ê²\u§ÄÈ„†Qx©Ó"o0	Œšv±)°|d®Ì.%"=SÜ¤¯|+Z­Ýs¥?_2»i_Þë¸Bo‰ô  +<üåÿG§¾ÊÍ¤¢/:y5³,iràÀZ­a ¤ü”¤wŠM”& 2+JzFBÌ€Z™ƒaHÁë’f:œ¯P¬ioaqùpµkÈBVÌÿ
+ÖÌS¨þ÷e,?c1. 2ŒË¾  K4×ÚzJGŒ‚÷¯KÖF¤‰9—R>Á ©PÀäfI
+IKˆJP˜_¯8'D¼~0v¨@Êõâ|øfÒëWTJ½;ÚY‚²À½ïaÉ@¨¾£Uµ©”˜‹Òe@  4Êù+63ÊÔkÄ\ÅYy£%	
+½EJLŠÐAÑ0ªÄJ„DÝ”4Âá°¡+C ‰Bqo*Ê)L“ŽZ'Ýiou-º9¶qîkèJ¤Ö[é±ý)’~\œ’€  4ÈûýÌE2¡ÇüˆyDÝÌ‡Øºl*uaÑA”•	…š0ÜÐq)b£H¾PÈ|`.uYFV”mn&û…i»JŸ?©+‚¹IÙ“µñ‰«9%¼šÇ[–Ð`  
+4HêRß–ó˜îˆ†ŸÕ‘9&©Ó†Cd„E[èø©»¦BÎ°LHh¡’`ã-Š„ÃNˆŠ Jh‘k£Råä­k’”-Éê‰ÈÜÍ‚U¢y$¬^V•.ª)E¬P   ¿4WéŠ4$t-WFuTýI2ÊE*ÁPˆ«‚„†m
+ƒe* Ø‘DÆ„‘&Td‚o„‡T>Y…>YIq»#}ƒ=k¾™Jcçó—,¡C;”¼bO=lÌÆcX  
+4‹ÒêZçu)«Iß¢)dù EÒÁÕâ×Á•tt±aá×Ë„’­pØTÉZ@È\«ÇN2òxú4“ïpW´¾Þ½)læäÍ¿ëÿÇ¿Ò¯ÊŒK ‚¨   4åõ‚Ýçd3¯¦É_EH,\Að,»@‚L*¡„C„„„Ð	†‰ö
+‰–.`òÙ•xi{QJÝûkÛúÉ®îZ·1OI:´ôœ¢„»Cša   >4v©S»U0œØjÓ„çZ6Ð(>\08Ðþ‰«	TÌÍW¡© ! rbrÙ””Põcv,!Ï1&úFRˆwúo'€ål&ø¯€n-Öâ÷¿¤ÖstpãÐ   Ú4’Æ§Ýÿ½ìýÙl›¨*Û @‚Ñ"BE‘<2ÁQÅÒ,h`Èù›BÇ34AâáÂÆ\e·F°©Ã…EH•Šã·.é¼Ýòay®	ž
+©!²é`aK€  4÷s*ØÓúc•r3d~È¹Q€‰–ÅÇÇI™&:VÄï]¿3hNH¶@JØ…\ eÂSdH	T¹®)/D²¤,Zê_Òs:×›6/VŠÜv_§»'+'¦ð  4ªõä§Xûoü“¢caH³KŒ¸`ðLyÀqŠ8"`˜TÃÁ¢æŠ
+‚£Æ/™0oÀùE†)ŠÌm"­+Œ-(hrý1ªµ~•ëöÿãóe¥H£D    ÿ4\ëëµûÞ–+Õ’Ñ/TPù ˜ÁÃcña‘Ñ'…–"FPº€l˜äÀ\$yâìLÐÖ¯I):Ã>îòí6½c[÷ôÊ!Çƒ¾Z­ Ùù¸"‰ð   ¶4”ócuû§š„·-®½=uul	¨Q‘CÂh ù$‰	"Y;£©›,>-ð.qSè°.’T×eÜä~Ñž¬ïõnÎ}íþ£w§êWá5”‘	,   Ð4¨dÌåfi×Ð¦VÚè•²é<.@&Q Q“aQ²2`xª‘ÆÝj'N@Àë' mÈžÖPUp½ýR—™Õ_yžäÔžï\ŠÜVÎòõO””"   Ù4Ç!þˆ×ò¹x? /h»ç	J$LœÈ\és%Ì$ØdXA a§É”Ej…Ä®í¥‘ÌÜÇý5¾rŸ±+ùô¯3Ò¤ýâcau¿­O€   Ü4—ûÃ×6Ðînð+òwG”BàU£d¢F†ùCBÄÅW(6`ºqÏ&4­°Éä–]rÃ9óƒ½Rè¸öÍœé×æ…JuÄ$­¿¶ÖEBå   Ó4ÞÇúÝNP7ƒ|'_ê„äõàˆªãÇ>6„OŽ54LÉòƒHL8¹óË²8p@D•²†¸
+/é‚£÷$ª«'€‡"2Èr)F½b·)3ó»rr,€  49Æ'¤~¥lTïî61h™á`¨âÓÂa ™Àxa„LŠ„Å_|ÑÀªåG\‰DŠÃø±0Â–;ÕˆÖ“YÈD¤SÉuWYz*üÑ!U4¦   4——ó=§p‹Ñ7«•Å7/yñvNŸx*
+<9ƒ‡E¥M®¼R@²N %ž7t@ølÝA[5Lš$¥œå³ÞÍü)Ÿ³ùSšæ+ÛÑLGkñ•Où–ñá!Ef¨   å4	ŒJvÇ¼£šéª,®;<¹1!‘'
+°,2¢ÂÄFEÄˆpLø‹¨A,œ/DuÇ˜#Š3Ï·ìl½ûVúÎå½å8’»çä¤6-ã$e@ƒD    ì4¯và#½j˜³=U\›Ê6X¸Š‘¢íƒ^8@â¡v†Ë‘LiBáN”¢D˜ÀXqV
+“0Ï†V‹Œ	i¬Õ&d¶=îòÑ·½üFsP¬k‰D®Ì©tåÀ  
+4Êý‰Ú‘»Ç¾­¹_b“æÔ®TX&äLØ &6DÅFJ	<>**ea$et
+(‰‰hÑUÛ@k;ù­¨ËéL#sÚÎãb½
+¾ý°#
+µ‹–›®[   
+4ÑÊÔ®OÒ=)ÆïÕ14}Á£å„‰—ŽŸ!Pû„„OˆLŸXÚàƒB‰B¡"Â‚†	²«3AWQ¥´ªµÆår-Ç“sÈGÈUãZÐ¡ZWET  24E°jG	)IgL¦4çŠž‘¶ˆ‰THt"ÑPð¹°ÚbƒCâãkTð@8@ë “&Î£|b}ªÁþa·ôz#ÃòxÉéôKy;2x7%olf>"  
+4r¨ž’uêæ[o6œª"&„E‡ŠPs@¡REFCe˜$> mÈhLÄL¨ØM‚ì“h‰Á½ŽE¨Rˆí€¬ÝèwìCI7•¿ðÇZêè¸IÁ    ò4—ùÞ3žþ–¨Èà´¿§¤Âh
+’2\Ð6iðß•tfxHz."`:ˆòNN|8}óÂÌÙ"˜Øíjü3û‚q‹c¹W–Â¶ýÊRã˜Þe>ÝÅÆ›Åo   N4D{¥¶¦lßÂåN6
+t-<4P(4€êŽˆÑÁa‰@™0•9ù ˜•È™5@µ×3geÇî’œ¨&PT1ÝÍ»åp-%)ø„{«‘
+ç¡ÉF&kk`!\“S%yò@   Ó4±¯’;9‰*|ób‘/†d	›,ÐùACBÂIFÙSÏŠ™JH&ØÉÞ^':p‘R£Åã(e\¨Ôkb9~°“¯-mù{{­-_¾,u*•vöe©’KÐ  R<
+é«|ìÇ»u6®F=:î<¤¹L,-?,$9")?)II -±Iã6¢U¦"§’’#2U¥Œ˜ŠíŒ­%eÃØ’’ÖBúBÜ×7¥,=[A‰[}å    ×4çÜþ­ÝxNŽ¢–Î. 2H8u±ÁCå]Ð‹ƒÍ’|hIÖCl\6Ì±Ñ2†±LL•#ñçP§€ü­#Ò8PîR§)X½[õO®R~SØ¶   s<Öšõ\TŠóÓfy¿æZ+ãå]ÌEÅbÁóÐ™˜‰ÊV‘öÙDé—nNU3*¥~ÕÓ±‚´ÁUû¥ˆK{ 3:‚›Æ<ž¡ÞÖrŒá{b¦Qþ   A<üí~½Ïÿ­¯4ØhýŸWˆ¤Ø+$/dbV)zàŒb‡ šÂ†š†¶Y6$:`HIP`$Aá&Ë	¸òÃ/¸@•BùIõ^ÝáˆŒŒ–rÛ¿Óê´&y-°È!(PCp  H4§o«òmEiÊ­ÌØnlðÁsÂC¦…AP˜ØP¨êÊDÊž/=`TüÕ£Su¤d%†­Îû>I‰“‘‘®’?T¥”îÀ!,BI'ÿl#“ÓžyŸËRâräå@  T4»JNGÙ¼®L[%ÏÒóÀ´$MˆDà"‘ÀÀpX$*drbUg‘™¾lFbÁÛ±;ÄS5â7%¬ªS2~Œ¨bS)m­»_{˜=@B%éi½íÏÒ¿1…’V¡[d*š*½   .4Ò«Åß,ëVÊÞÅûœoÌÏ†04laÒC¤Â¤‹¡xY¥ U·á›N<ÃLˆFã«÷NS±,îÖ¬uBÅIÂŸD6ÀÅê¿­áA_E   4„*íµX¦C›Ué›ÜšÈ	ÝxàP°@4¡q…W	œ&Áñ@šBEG”„“,PèP$@“F<$Lf6<¸öøJ[  ÅŒþ½RÖt¾ó~=e¹]Põ€   ô47žehÊåìµã;2#l(JiaãâÏÊ Ò!÷ÉˆŠ-,$8±ÑFo†„B
+ºLëäçÆs™Ú½º—Â¾÷ •+Ëêv[u´œÃŽ')äÜx  k4síŠ2<eú«}E¾¢ Ã¢ÂbÂÃB`  @uÄj©‰ŒMÙ“¬¶)fv°ØÅ›ƒcõµÄn?d¬¸c”žkâ•îW$.Žuzþ1Y¤âR/ËY»«9à3É¥   I<~dkC°ÞƒM:Ï°Éä	ÇÄIŒZŽZÕŽÅ™a:A	qC"•sÇîÊ%¨vp|Žé!+dÉQŒCò©Lco €f„¨wbs<MHä;w+™Héæ¶™JB`  84Ÿ¯Ðæ“Uö¥µd"áh‹Ñ`°ê ˆ‚ptñÈÝž`d|ÑP êÑ²ÃEœh4 6.YRåL40Çâå$83nnéù:¡ÎhH})¯vd÷–¡{’:Í»(:  04¿Nc9 /áˆõó´è‹tzàúÀšÀUIp‰ph]‘1×§+3P%|”±‘kÖB¶f%-m\¡»HðÜ‡`ËÉ£\+JG¢}Éf-g)Ýæ7z[‰íd±îŠ“2Ýó   <
+ˆt>åNéeë–*_æ¼ìÕ˜?"/5/L;9¹bR#"ÅF&©
+Ô6/.r~¹ná9û‡)Jž¿"ìÐnI5>1ÌþW¸þ;ƒèÄs¥z¯‘kÄyÚÜ¨„ÉÏ¢l  24ò5ÏÝsõÉ^ÊÔF€¤ a£ÁC†ÄAQBFDY$y‰¢‡ n	„t`&"xMI#“öt—ÓÔzßø—JÊÑŒT×ÉiÎX¡ö¿ö†“)e«    4}ŽñO7öÕ©oËÆç]F*hd¸xdX¨Ø"ÀÅ†Þ\@l Bv z:6› ±‚ÃbéÍ«I§Æ¯ÿ›hŒ/±®‡¤ó«k0bè¿Ö¾«ïU9î¼¸^T\H¨H   ÷47ïN>òÅÌªÞåàì¨»š‚ ÂA0àÈˆøàÊ››Šˆ66@°°"Ð¹lÓ÷Â¡å"L	gQ‰V&ºHÆùØÔÇ1µ‰ö™ÁÊø±à¬¤ƒÍÊTzR   î4õkT:“ÌÆ2üIŸ´‹–^AXa€± €I‘pÀß,PDð¡A%Ë68"±×æÐ<\b<­r:½ñ“ q9Ú¬HRôŒÆQœÿÞ[¿Þ­ñf¥tt”õx@  X<z)ó—ä«Íçm~‚
+ÓMDT­—”2693©œÙ¹³b3GçÎÙ$5\%;™'bNéÁ%øÆf…”Dgé„lÌHMDñˆÿJ{¸†ó”•b%pj®   R<zaTp&²ÑïF’¬)ð)|ðTíØ”€XXfN;’çe‰Ìˆ>,3 > .`5n|èJõ-£ä­Q•ÍŸÝ³É«IªF³Hª„Ò/‡<rÔRq¥n’gk§ð  4ä^Kiª¾RÀbŠ’ÑY§Ô 	8(`24LŽ‰Ia#çê+h.ÖˆÝ±5R"%^XB=qäVµ;‚B	¥UOv–G"^íVÜý1ˆµVòÅêµeNV¼U€  4ŽÓéë3ýnÖšMC2FYŽ$ ËYÊâÅ®…k_Ï’^#(.xÌÌ$\šÌÉW´Z‰Æ3u=.TÊW°•Û9žþnßÖjo‰‹ÙZx#1µMÊ€  4™Ûè·Ä,J÷OÁ¡i’‘H4>Ô\È@ LðÙ›:6 &Di×†ÏV|éà™ÀTäÛ%PÀ00åÒåc¹Š¥#Ò¡ýà9´Ì·b3’g4¤ÌØ*_Ð  4·v%¹û[Ÿ¯SjN‹Ur8ˆ4à*˜Ð&PÈ8:ÇìNœ°!)+JJÜ¹©¹"Ab"³RçG-ª_¢rŠ”b\4I;`†',…¡‹ñÌ#°KCÓ4«ÐöOòŸ]rVœµÀ   é4êöµ5÷	;|¬^ˆœÑDJ:øpË“L„|™³!VžÐ^,¬DÛFŒŠ,d02H˜“ÈÓ&¼ÈÅ2qÄŸ¦jøbO2y^âíZ˜	IqƒýÃ¥JL³4   >4½OgÐçV²–ÁLËr)>u’ãâæGƒNÅ…@\Vô±É‰z”ƒ•$U„¬w55¾"xH‘’¤C'¸¡œ²ígÇ¦›ä”géjõïÕèGy¿¾ ”¥¤ÈÀ  =<vðémìs˜Ç£+ü^&¨Phý±<´¹˜ }^’±"%>WDDõ¢‚âwÕ	z‰[S™oOd7ô0¤´LÄVt!3Øo½årŠo¼åÊtÿðîùRbKP+€  4¯wêó{Dò+­ª‹ìz°àÑƒÃ‚@ø™€df¥:láVà‚!Ð¡æÌ	¸§ÈWhM•oŒ-E¸C+ÝŽ|‘ )Fµ‹Q.ŒJG<'+pcù[¬Ö‘   4»;T)ˆ¤ŒŸæw	ç¡ÓöRL2*P‘†øáÓÃ)‰–+|*q0¡âÄÁ Ú#âm<miS£;‹é}GRŸã!{ex»Z7Õš7+Z=-)HÙ9ŸpJè  Q4b`¥WkÒûàZêa8IsÂEC$B°ÁqÓ–¹;2GFýÛ“‚DU$Ž"ò1E±*¤Vc=r2ŸØ¡wRs9,)Ôþ@Íë`S›BYËú˜¸„©ŠXð  (4ób/•ëu¸”ËdÄê3Ma£â¢§O‰Œ‚'Î†Ç^ü™‰¡²R¢Æ¤¨†ŽYØ%=½ r0!¦NÁXÅw²>ô{C=ÖR·+øßp	ÙûkFKLú»Ù   C4Nks"u£8Î‡!(øb*T©aq‚‚ƒãAÃI1»
+šD*2t0PH `T“¢ ™…¡A±qáCªÒ.ÏCfÁ’Ôsøý NŽúC]š™’«=Ý\Âôy=YsOƒ@  K4‰`ÔsVd+áµ?‚VÃ0™â„‚£kÇ†K™¹Ú²&&NIY«<@`ÚzT°Ô½ÁbbŽÒçt…Ï@1¬È[\NòeÍù+™ö–•CÞ†S‚Â@  ]<„øyÈ±î¥áB%ÎÀº°UvJ„ù4hÒ”ýàˆŒ¬ðx‹HÏS”:6jÜõûg‚ñ†ëBeõ‡Ê*R ˜¤ñÔÜ£ÌS­oy¬;ˆ®VkÌØÄ?)®²±7(9:  H<Qê®àm’¯©†Ç~=edI(_— l\$rìP4B§M˜(:ð¸±÷Ä‡8	²\$0 2 ‘QŒr|gëlÍ™ž
+az¯úÍ_¡F„‡AË¿­µÌµÓ¯H8  Z<
+<Pï Ì#ÍîÛJí+Äò„mJ–ž‰Y?¡©[W®ÏQ˜–&%hð`ÉyXˆÐ©W÷¢t+ÕŒ!áR—£7
+ÛØ‘î-.—ô=oU$x¯hXQ„.  +<B,­jôíÏAÅm6jKâ†ïÙ„iíK×H	‡DBü„­ÃÆäæïÖÉKÞ›+¿gôhhí	ÒÙ2ÄÛOÅs‹Â,µ¶#ŠSîGZÑÌ,ùåç!Â[Ë¦¦ŸŠúŸ(  	4­rˆÍ;ÞÐ”éû•HÈ/háÀeùÑ!PÙÑP¸Ê„ThxmâªÁbæ…”¨8,PE™tü<1™UJÔ‘Jn“‰QœòRæ¥%wêkº¡Ó31uÇ   4Ò‘èo€¥|Ó?±¦ü1,Ti€À"D:>6XeŠŒ	(2 ¹Qq“'Dž‘Æ‘&¨’¼ÆKÅbrc+v'b¤ì‘ù!¶«5L½-Éxâò¾¼    4[·¼í¶Âø!–NËÅ‘%‘.u€ˆ d¨€ØÁ"0eÍ(°ñ´'Ë+_¢ž>µƒD¹‰ŒÅÔšëý‘ÙÍÄ÷£%è#ž9Éñj•D—¡eR  84Q·××ãý»õ¬×Ä~l5*€@ÀÙQË`ÐHèÀëMÉL•¶|&VáÓD¢Å¢ÕH?ËVš¢%G§qàÄ¤ú!¡ÎLiúéé{·¾ž§õ¸ä¨Ýô©·¿ã=X‰  4âÅï*ËÞÄC¯³)‘9!wg„Ÿ..(
+‚¨…Æ6P  Èðl™¡D!U†Ònè^ÀY]«˜™•o'B¸—‘ÜZ”•þA,¯Ô–ïÈÎ%è±á_¶   4„ç8¡B_[2¸ÁnbÇ¾0Üd¸x|*Ùñ„Bo†ÇŠŒ(eòÀªtA•GË©(QUÅAZ¦N©à´DJïŠZ=%{›³èÙžã˜½áÝ¹X¸Ê[jà   ý4»J÷@ÅÂS;áfñUR2³…†Ù	ª:lÈÍÌ
+	’t¹á"šN@!	¢û"­mË,3CÁkU,uª¶ï~Ý¢Tó•¡­_4º¬·ÀAÀ  Q4ôeþ5ƒ»^±+Hýr\ªAˆñÃÇÀ™áÑÓ—×¶!~l”Ý)ã‘
+tÒ²ÕÆg¤ÎÝ£3wéPÄæ‘ð{»¼%)Ç	¹+ Œÿx„*…ýP(”°Æ’  4Hv^3dBN·rÝ±Á‰!éóœpDPˆDòÁP¨Õ8	‰°6h™ÇM
+Š²8ØU…¢`Ù	Q‘e’-²0„M¢öèKƒ>’µ•]oHQêõÝF«ñKŒ+)5§Kf  %4ËoÐF˜'RFÁ©z)]ìN6dQÑ1¥bb ‰"aá¡P..|@¨q—ƒOŠ
+¬>¼Á5ÌsëÇÞ6 ëÖG†g:êìÝ+Ì¡-Í	+IÚöýö¯¹2¬Õ”  L<Zútç*ó»…J¯íDò$å„eÅÍˆX”Z	 ÉÃãƒbMÆÕ0*qXùõçAS¢bçTdÊìª3Õ9	ÓòÄ€jÅ:¾ÈÇ¦.˜›Þï(®ÐýÓ¼º   ˆ<è2þýÒQ÷Ý/Ý;:¦)d@-2~5,9430-3ˆíˆõh‘Ð…ÐÌÝ}pˆ4VèD¨ù²×cõn5&AÇá~BÜLo¶‘Usó#¦©¶¬ì|ÆòÈ˜r­'å   J4–àbýqÈ:TöQÂP€ªçÃÅEq†ÁAæ!'-|Nh¤¥`‘8¨cW"(h…bµUî›,EHf1Û)"Ö“o{)–rT¶QýzÍ:7äk‚øeI™WÀ1p   í4j”nèœ§5*^“ÌùésgŽ	™0ÂBÅŒ(DhˆDÙP«ðÑQP˜«äÂDˆø8ÐÞ¤ºâ5ýÔ^€ýfy-5D!Þ ÖØ“• ;ÕbUf°©    Ô4;K"v­vÝ¾¹
+bR"#mËO(6 \°Ñ:LÁAu‰ŠP*xA¹ò
+
+ºp¨²Òm"` ÎHRå
+{IL‡¹ü!¨®iÍïä•l0©×Þ5)¨¥€  é<|;npØ×h=Àæ—nŸz3ABš£`Ñàˆè¤%“ÑÉ‘¡óƒÁÑ1!p¡€Õ€€$GðÈZh(.\~P±0€wôLóÌs¾—w};åt6ô¿ýé÷î"þÊŒÌ]	€  /4šÊœ)ø,ÌLÓªK»(ólDÖŠ‰„Ë‘êØ7c#!R$C¼™€¹y1³·kÄLÏ–Œ–k+Z¡8Ö+$Íéä%ckÖoi~r˜r¾¡þÖ¿\ÕdJL¬e   4	Z´¦ÿ¶òù?Tö&,>]ñcçJŒŽ‘q1fÎ•,Døl´PX¨ÚqÓˆkOºÔò	Dží±„OX÷¡Ÿÿ½ø÷¼ÂZ;/ÎŠÅ¸ÄµU>•%Ç*   ó44þýmKQÆß”ÉçÖ–—>* tèÉ3!‘‰º@YarA¤ÅÖ6kÐˆi?Å×ÄHµG1æ¦%tƒÆ·’¤g€¾4}©Ý"50½+¡JXä£mMmÆ	À   í43/œFÁÞªñsý9vÈ¼AÔ(<8ld¨Q8˜ Æœ\ØÐº·	*ˆPHx„@$.éDK+Yq¨ä³o^˜)xR†æñž•Ð~Þ&§nóüKšNcÑ5q€  u<
+ˆiüK¼ØPn¾¦[ŽÐQ*d±™Cñ9œüÑÑx°u¦e¦åÄ‹ŒÍ-¢˜ž«“’	†Æk¿–	ÜR°J¦¨Õ@b¨åzà13ì1ÜÕèÎâu¬ä_Áy›ŒÚ  P4wZjb€‰pV–Õ/˜ääè©Õ¤‡Ë´
+'Ñù 6|XN\éÉòbc…‚&ªddF§ÔT		êFÖûGÿ³Þ$¡Mg4{ËbsÝJÈïBC©^œ FiË2j  H4
+éwPö]Û˜Ìo…¦A˜ÈD‘—QÂ¡áQa±ùxxRÈ˜ýóÂD¯[—½+E.8~D-f¹©::d3?m£Yy%LwüÅ0-ôœ#íÈKÅdþµo­ÔàRbPÀ  {<M9híÖÇö|oøŸVÈÊ\•#¹=,(-7n;VÆEgnÍW”“›.)-1B9X´ rRüh¦Ü‘Båë†-Q+;Dþ¨ØšÌÒÆJ5Ì^%î²ÕržŸ•>ìÏH‘@  Y4NKü=„ÝË~ÞVÁÊCaQuâÃÌ†E„…ØóÓS&j_›+‘2^ÐÌÍ“2Qsr7MH•'òèc3¤Ñö_2ž†dªêjNà/í¹ˆ¤¨ôäíLk¥1m‰   œ<>ë°æ‘c"µÃçŸu¹D26Ž‹Þˆ—	Šž©˜¹aË–§èËLJ7+h*@ô¤ÀZÍ©K6õkFÝ“/Éh§c‘‹Üôb=H=îœ•(®c˜4ž#)"Lè  ™<	¿Úl7À1ÄGm­õ7žÏ¦jÒßˆ$¦5ÆÃ­,*£·3F!p."3(•6^~n^xfí`…¡Ë‘š°<;‰hŸa¾-†ª]…ö‰^«#=ÀœïÁy:Œ•›ŒEKÀ   ä4û¶bzÌs#ÏæÍ’•Þ,TlAA!s¡&ÆÃfÅÛ|Øe×‡Y2EãÁ–©žy²dF^,àßìª
+Ž÷ÕºCÙ¦=•Þw±%RJ‰ëTù£´ÒM¬  Q<x3wµî9ÈÛ­s/^õ,nÈ¸¨°¹À•¹ó‘¾p:¨iÐøØÑp‚ƒbÄ‡¨,"	„Í&,.óhË<ý>-í?£ò#õkÆ¢ªø¸'¿Àf¥ý°G$ÇUt¿ø  49waâ˜V§[Ñ¬¶®Œ8 ¨â€Óc'‡ÆÎç5›ß‹®L$<È‰1òèˆšÌY$‚£•GÁÚ¿Ý`V¾’uùHWÈ¼×Êo%ÍMçOÌµ£Ë€  4ÕÊ_st§ëVF÷·+ž–8Ø€Ø™³¡ ˆØÁ¡q‰ª³8 \`Ù€àcÇ ²Üˆ‰‹†ÔR]P’"Ë1t_oX‘4nmG ¯Uní©LS‰›èÒ²¶Òà  $4˜ÐÌKç&á?…©äSV:	p°pxà
+ˆ„Í°ñ,”Ý³Ò‚6OÅ._9®n|`LPÌJ£ú*tUƒôÁ‘YlÓ½+àå»² ¦'-È-þs:HyŸ×¦n Š  4nß±
+UèKy³²>Ïdj°>	FÄÆ°Xø“"à¡‚ePH†TD£ñqA½LŠƒÜý¯-B;ø5oØÍCÓ»ÖÎÍæ}*55*  4ZÇ1í¥wÒÿµ³—ˆŠÉ¬|:u ¸ØÈLøHXcÌ*00dLŠ°Ø±×AÏ8<úÒÊ¸ÜÓ–8œ§5qŒ\
+uJv°GË³4OÂŸôÿüÇø0…È(   ù4óIì ¥B•¯{ŽÄûvé¦Dž„J˜a3ãxd@ð€A¡1ã†J4(t>\I+ˆR74L4õzÔ›ÀG’•º•ç‰í\†eèÓ©ŸÞÑ±OñÀ   ê4¹¨½¿÷½¢-Öìä¥`ŠI‚É‡‰ ƒ2&ÉŠ*°"ŒHY@e'FAb/pL]»"mÍëéx{vs¬—¾'ìCÏB×qOÜvåª¼ØTb2dé€  +4þ+/t{¹+W]/X…„_
+„Ð41ÑÑvA£¥Ož|h¨|i yeÁ ¨ÒË‚¨øqá•™IÌ
+ý¼vHì¦7¼‹lÄ'BŒvôË±Ý%èU.ZB·‰  –<)qÒÅ^]ú²¦½¼!û³ëÂæ$N¦"³1	@b9áZI’ƒ¢¢3ÒrCR1@ÅyÐ™³à ¤ áãS35,RuKÄÏòhäù2¬ÏoïtSí´i¡e‡aµª·²Žr  4­Õü¢7êgÔ¿ÊðR6€á7CÆÎ¢ï†àà¨QÒãÇ‹TdDy0\©a  0àTÂe¾¬Ö6ºb3ÐC`­}­j{é]t…<«µîæ7ÝYÁÚW¬æ   Ã4	³¤¦2ŸçWüìWQ6¯áqCˆ„	–(1ó„Ê,añ"«šLD²¡—	š;m™ÕR²¸ÌxAgåvt'(ÿþIÍeRM%${#Î"˜¨ÁYUÖ@  >4!VwÉºÔlVËší
+ÎŸv@	ˆ!!Ø:ltÉyai9C'ÌÔ¸¯+< R7L¦É"â´ÓŒºÕ¯e*…/T¿œ{ð”CzñZ$fõ£d«ò|(  ,4%)n%˜N®7èe›R²Žü€2 ðéÁáQ  `Ð03!«Â­„Ê²™	‹6hèuƒàÈ²`‰”BÅ¸Pe­ŠœïxKV‹äzæò²¢8JKß¨ìî3Ôþ/5ð’   4ÄkÉŽÃU³³¾¹Rúøô,Ã‚¢g„Í<XÙ‘Q–¥B…I>ðT€ø›qÅŠÂ.©.§²iŒ…—ÒÆJZ³¸‚xÑî	o¡Ê§¦¼ð/®¾ø~pnj×<¼  45v´¾ums3Öt+¥´älÓóa‘c#c#C`"D¨ˆD™Ól¼:6T‰`©ÆŠ!6‡D ær¬™”«?5[µ½…+¹à×öfú!³øS®óÍYU¦'ñ#   Ø4ÀµŽ¥=ê¦ø=î•¸tÂbÇNœ|&8pð¸Ë}££ÄZ2xàª(NT Lóª~3ÉÂƒ¶i—eÙª¥;£bö>II×1cmæUüØ  4ÉhÝ ŒÅ1ü=§­QÈ Š ‘¡ÊCGCŽŒP"èXÑÁ’$‡XH	¼¤0]‘° ÈÐâgZpx´ÆçD˜ò{šßpÔ{€
+±úF#ûävWQ,¨!ô½   þ4òŒ´c2')µ/:Â£#*¾6ÈHøÄ20X¡â‰(tQ*AAFÅÆÙ6Ì³?JkxÂäéöÏƒ”©%üî—ïú^%b‰‹1[JÌHvA    ã4Þßó‰Zëžõ±ÇDÜ®ër§O¬\$.\Htf$eCí‰´pÁR†•T2@`AÓg¤\|UôÊ+³A{;¨ÊáVB®Àè>Ž
+ˆ¾+l Hä±€  '4¯^”‹ó’£j…2µIŠ£$$:P›"³Çí®M¼pBäÙËCUŠ‹ÄÆ©Ë	—¹WN@®iâ=‰Jº‚vB¾
+o¤+›¥pÞÞ[‘¤£¹S°P  #4¯cÊ¯W¯£y—ß:£‚d
+FN‡Ë… *hp Ë¡’(…„L„
+':ðØd@4X¬£n‡ØL$Þïª2ò{ÜñBÕšì›±ýÙ’Ç9z¥Û›r&†   4%)‘jñË{õ¿Ösv‚,4&d"Gžb2Ç¯Èš´,!^PXùÁ#‚çoJÌÄUp±þÅÎZ$¨Ÿÿ/3X7WJ;^›ÄÅ€Oªš¸½8±	[B   S4ÉS•³¼%Hjk‘^òâñ©O,„–€dtØèéÛ™“1¦##"jrXÙÁ9ÁË¦ç¤e®?\±ÂáµÐ¢û£¹|Á*kâ\ÌÃ¨kC|væøÁ	PUg€  Z<ií3	½
+<ï1ëÐ£º~|mJè+)º,?,?b;Sb'lOR3(1jxbLà¬@\–PLð¤”°­–Ej¦Av_Ê¼Ý¨7ù­CÚÈÆè‚–—¯¼–)º!2‹±  B4ˆa§-O¼¾ÿ­·cà²TËð‚³ ˜øX& 91)ª3vEM^—¼X%%"5b"&3=1(FüÉ>³U³LiVÊ÷\Sú`ŽAO¤îé?âÔ_k£´~‚KÐT	!°   ò4-JüÖü•ŸÓ’˜°¡©–@@tÈ\Ë£ƒ'Æ:$*y3BåÈ›t|Ãâ£ƒÅÎ44´ú(pjÒ{Ì3b˜G¬ÖŸÐüæ¤3Ú¯”oo²‹­¦Ì@  34j[˜ß3>IGº_ºŽåfˆ ®Ã…ÁÒ@Ðà°" :ÂbcÕ	ˆ]®(.?Zf'x¨RzrÜ½ÊIÇ‰ö™tÛÊ§MÆ.pD1ÀÌÄ%Ùxgd«ÕÊ¦dÝ›Ò¯ð  4ZRì½Š–rŸÓ¶½£æ÷Ï*pÑ¡ÑaQ° 2H,:F¤jÈˆÒ‹_'îtðÃ€²£a3u¥«—ç"A6£©é~¾¤9¥”­\b•hOé'­ •çl¼T”ÞÄØÔ   4J-s9Š5~£ÖÃØVUGÖX`è“‚ç‚#á– 6*x<†ä	"`h(´t 6&xd¡ù,dfgß=o«doj!àç›S£rävÆ™¿5^Òþ¯-&è  :4öŽPZ©j_Ç»è•R
+É«.\`&à(ß9$/j0váÚËBób—¬Eî
+ÄEEb'„jP— ð29x€µXDZgðváH†R27#$å|ßø®Þ¤ŒÒº~0   Å4
+•˜ÖÝ)­²1ãôKLÿ,ˆéH	‰•	aÁ1wŠ™}ÄŽ86`ªe…GE8t±Ô±“Hli‹Î^Ãë…4Â×”óúsÚ×ììZÍ€¦JZ¼ƒ`   æ4	ío‰Z½ûC"< K†mš4©ÑÃ.	@¨€‰gÎ"é1chŒ	‘xd(D\¹Â2œÏÐ|×ÌWój¡nxçH®þÄ|5ËªÖ1–Çä×‘ƒ™@  W4IWÎ#R##_ê*”­QJæ¦Â1€¸8"bá+2G§.J	R>XpDÔŒð%^¼Ì©‰ªfÈ&7h‘Í²§R§`¯Fè‚ÒÒÝ‚¹ ¥')ƒå›TÚ4   Ø4­ˆ‡u/ï~²ë¶ûŸ0`Á ™—ÆEK¼1qb2
+*ˆ±b¡&ÓŸplM˜À ‘Ár†‹sldûQJ—¸ gI­t—¤)…ûýŠBzæÞ÷Ô/-Oà   ¸4nŸôð=%Æ|o®¦­ È™##‚èD…NŠÁñQGßP` å@Ðò:˜Pð$à‘£'ßJ‘ÄFKäVÀ#jLWŽ¤²ÚÇ’Úˆé„µ]©Q¥Ác    Ü4˜œß›õr»ì†h^ðº¤„…K††BÂáóâÁaÒ¤ªµ¢0&dµÙ18‘M™«š£!R¦¤Ï×rrå(Æns §yÍ`=T#¿³Ô£Ü‰D¢"T­üŸD†Ý¢Œ@   Ï4@1îäìt)÷<÷Kj®%*.*|L6&H,3í(*Ñ°š&Ë6>(°ÉjA’aÒ$Ê
+©©ÆV¸<§÷Œ…vòÇsùõÑ;òÝ‘½O”I–ì©Äà  <šÉqk%¡ÕO™=FmTó9C"’–žššœnÜéùásó¢uã”Å.×š©-vb1("$xÅ©‘’ª®8Z×Îííí»0—œF(ŒF9?K)ž¤u´3’ÂÅ    ï4JmBO°ÝÉšu#AÂúM‹­ð*lmà ¸`2àÃÊLP Ãâ&Ç—<dà¹3‚ƒ£Á'O tÊóÄÆõ¤öP½$1K@–d'}?r˜B#÷K^ÇZU¢¤e&Ä    ù4·kúÒ6yÂ×YgŽYº#\éaÒÇƒ@ˆð¡!¾%|}ƒf	<,T,D@&t@(&•6ð¹¦	,6‚é(ÎÙ*o¬ÌTÉ¹½ý’ÚÄ{¹%:÷-³bX„4  )4ƒYßòcÞ®éK1|
+°H™Aa1C£b€˜X¸ðîÚ:?+bà•ËÆfnQE.I†/	OÊÎNS$, Y4B/1+YN¬y_]KÎÊùÂÌÏ9A=ì‹uŠëÕ!r°  54+ÞÆp­^-ÊVÑ¢=^,ÆBÁauÌ‚¢‚¥ƒÃ½`lJÉáQ2d$æl…©L†…¦æ…I]¾S4eFÀþsl#”÷±?¬ô{ZQìZ ~$ŒÆë0°  N4uýk³Qk÷À§ÕLÒ=ÑãnÕ}:ë@DltxDˆ‹‹Í¿:fTé©áƒƒ£²2²Ñ@¹©ÁjänSLœØ‚x’«‚‚›‹þ7#ìBKX…ìåŒhˆ±	¹eú   44ò®Ñi¥/®ÒÎ†è†ÖÞt°HÙ!€à:|˜üº120¡Ö'0døµq‰ÙÉ9‹áiJ’³$ŸËZÍzfÊ†”‰]¯¡»nóFbõ¸¾Æ¨ÉI{©‚2¸C€  f4ûÿã—>Jää®ÒÐ°aË¢‡Ê˜…Á¢C¬T5)bXBdÌõq²Â27ã—mEf%e¯• EZ‚jQIŒÌþ¤ÿ…+ÉlVgQèž"Ð¶Ez½‚êµ(Bª(  4ïžçoT·õ~ÍuhëÉž	!EW‘ñ°š§t®h$aÑ ‰ €*PTøÊäI%#2—¿Š´:Å ××·LbÉÚT¥¹À)×–µqï¥sp  	4N^­Ëò2û¯0ÕVE„°,<ØðXÈHdàÈ„‰Œš8 ¹P€šÇÅC‹ˆ«ß06³ÆˆMÙSÊR‡/á×œ©Äêý=þAìë‚t,HöÉ2²¾°„   4ÖSêÓ²¹*¿šßRwC*àL*Èˆ¸dDXgÉ…Q‘
+“*tEÒA"¥ÅÑŽ‚ÎJ=Q¢*Î=!)Á‘¤qcjsÕ&í`N+‡á	ÍMåXž#;Xix  P4ìú^GéºW­Kâ†åÝM±5†A@¨¨Dð*l.:brw¤ÏM‰„L‘Þ:%+R#!Ddd)5br\ÎãuªÆí€¨ÜÇÞ±;ì¶Š	ï=F1N j]‹¢úíª_Š¨!‹   V4ø)zÆÑé«òU„~«¼‹	J	86	2bÁ0ˆó›=(#(:dœ`ÝËÂ“&ÍŒÅ¦MÜ,FBP˜lÈ¶)‰Šuêùg¾lQœ±Ô¯håj[ub“ð./p™À  N4¥ff¤Bîâ¼ò+»ÜQ ,ðlá°@ÉñÀÐ° õ•˜–!½pìÙ£³fnß•Ÿ¤äx$|ä¤©Òo(ÆR$¥ËaJ˜7ýŒÂTó½c™¹)	ŒéÈùV_~ÑfY°Á   a4„®W‘ÆVœœ¶‚™­æôžPH6,>2P44.;"UŠ
+Î^˜(|fÈ½ÑÄ¡´´„¤‘Ã4T®UMÑVY 	âœ";IUÊ/°”Å „ÔÅKÝÊsqS1é–    ò4	Rëê’Rœ¤+[ÎûPž—Í£¨°Ø‘£âB†UhmBŒ:<>Eò¬\L&(ˆ¨ °¹÷F$FáÇÌï[¦{æb¥lÔ•îFí!/2Zí:TýCY%C   Ÿ<
+Wä´±‘Up&²Îe«Iòó$OŸ"¥‚áññ©¨û™3
+PÉÌÎÝ<>4 1).@–ÈiFE„–Ø$šÐ©r|KãvN…¯çô»~)-Ú»ÙR--kº|ñ¤·ðy°  k4šòÌÕªó–íþ¤—ª¥8:00,|ˆ4
+¦\HlxµÑ9¢÷§$&d$Ï”•¦/ g^PªdK0“s!Ÿµòsy™ê!è×SrtdI?Â|)­jq°  J4—·¤×–$­ÌÒë>ø®¹BCÂã¡ƒá`¡11Ø1&>nÉé	šçç,œ–—“”¯7,3j„Ùã4SvuƒS‚·nUÚÅYlíÆ¶5	ûÐý¯ÛÜÙIÐ©  "4½Þ²Õeëm#Bí38{Ã'DW,ždaáC\0\ÐPH’`€Y³aP°›£'Ú
+¬äU˜‰”-/OÅ±›¯_Ëäî7OXŸ¾DÿïmZFQTœð  (4©õùTèW’Ê§KÒ¥@±£	˜PéP‹„BBl:$lùp°’± Àá“¦›¹B}®Tº“ì„ðv-L÷Åb¤|æfBðZ~©š¿™31‹Æ‘€  +4Rj¯wëÕ•µæ§hYø ‰£‚mCEÂÂb£ã>h<YÒãâ,…Íˆ688Á@|D>aÑÅÙ–Dmª*ýí0Ô¤^ÀÇ¹°ˆÒ+õp+!÷Zf”Îò6œ  ˆ<	]Qèó$í®«vÜu:¸‘¸3 bzr@b1¿X7:qa)c§…éFÊ¦ŠE®
+'‡H‹ž«µ3%šäB‚ö¹L¥/bu'õìÊf	á-oœgAzÝ:wÉ6A   !4«bÿu«IQ£'ò7*iêC‚.:‰ˆ‰„Dù“‡††H,x\ñ¡d¢¥D„qã†Ñ>ÅÑIµ
+§nÉ;[…qê¿³ÔãHÊý‰ËZÚ±*ÝIj!t@  4©~·Ny'#Ûµ¨.%éÃ­®&tL.((,(|a…ÇDO,,U!@PêQ±Â‚@ˆ€‹¥ÆÑØ Ë³^`ùfÿ@õ8ÿ+Ï±qŠZ°n#cü)½vU–\  A4	Ú­'Õ¸Íjwüv¦äLÂÍB€Ó#Q‹› 2qÁ³bï…Â-…„K
+‹s$žA´F’Bfö ZÆ¸êÝÛRÑ®	B\.âÅìÒtJ[–1Ð  '4:r[Ë1Z[›½å-i¦"Ñ7FÝ>Ž†Þ  “‡‹(|áqSc‰Å
+
+¸Qi†Þ&322˜—5OZ¾ØÖSÍfeu“Šnœ_Âñíš”&j  ¶<r¼`ZPu¾ÍºÇjBžšŸE¥ÁðöÌÇNÌ‹Z“ž–ß‹ÊLK‚Ãgg®†Îæd@ÞüÈ5rRgû²Ó0Zõ5FÐ7Vô·øòm²*)  4‘ÈVí½éÌ{Æ:eÎÍ	•&H46xØˆPT˜Pg‚%Dˆ	¥&`\ió¦ÇFš
+‹h\H…á¹°,&O‹Xw¦íÈÏëiÉ?EçüvZõŽêÉ©MVl   .4­ZVÞ×&iÉàŠ½fCÂe‰4&>\‘QqD¥B…Ò8&x\tÙcQa šÖ
+‘hQ¡ŸŠ©rÓõv—¢-)ÿýGmcBfÆáð—×yb0  ¶<»Qd¿£ëWU%ÊÓ×Ô~^ˆÐš”¶”ˆŠÍ„%ã¾8n~à´ ¬¤ÉÑú`„àˆ¨ˆ¨|VN,&TTÕAZyâîý>Q]2›~ty*½g2»¦•oÖÖZŠr•HlH:PŒBÑX  34½íI›4~”™ÆWS'?ÆHqJ#¡!¡SÃÇ ’Ã
+”}`LI	Òƒ"È…FÄÅŠŠšxT²²GæáCnk¤¤y’ÌÅ­&hHËò)dTw˜î–Œã°·@É   4îäÎ4gªl#—þàÇüš^Ld¨™’ ƒ‚A8p.òÓ¥‹œTht‰ƒ£‹„O¶4P¡ÕR™54#‹jž·2«/|ÎÔbD:ÄNfZ`NGYZg©O)¨   4ÂRÏ’‘ÕéPÃôŠŸháa„„@ˆ™ ‰á—>À‹âm¼X¨¨‚Añw^8\¸Ø£…’`(RdgÊœàRlÚŸÀ·FbyÙ·ýh¼ŒØí/E(ç‚ÒhaR  †<
+?Wtí.ëß'êÝL=x)úùY1BQyº2ñ@ ÄÈÐtïŠ]”’“2/nðZ®¤ZzÕÀñÁò¢'^5A4É‰À5ªfôøvý(íˆîÈ#d€üõ¹Á×e¬@   þ4
+UÚNÖä{’ß¤¶ïõJ¨P.yÁò‡ÅŽTéC‰ž6H™¢ÅhÀH}{ ‚¤Ê:ËEÈMƒ9Å-æíOÅz©°­ÿËDûª9Wz{0†’K¸  m<±uóöÚ§I½fÖ;5’z~ñã×‚SçCC¶çgÄ#®.vHääµy‹åâS†«f/Wˆ66TÕ«ÑY<Õ•ÎSA*¡èï#_‡¤êÄdøÖj_ÝeBôQÙˆú  g<þÐñQyÓÍï{Ù~.¬&M1$L$š‘oÏËG¤HðŒ@À ­IÒ3¡*:‹ò²¢‰!qòµ)	Óz<H#ØkaOÁnŽqˆQÄ5#nÝ	ËXOYªÉÙÔU”7€  c<øRh&«¤±ÕçÏ.g´5èÈÅìŽL…‡FOËG'/39_|BPTõQ™‰€ñ…™!P@¼¼éƒ¤šl0£"ÂÒƒÜØ‹oîìüÙºýAZ•Oý+Rf]AYž˜}0  )4
+cRõÕ*¡+3W¼ÝR<$`
+B¡á1Q’	œ`XdIò!  ’pPQ‚Ã ¡ã¥„Ó²!#“6Ÿ­x¬V­È†‚[ÉÏÙŸÇ©KNTÍƒ‚’™9æ   44­÷#$°Œ~FÆeiØ*$0p:ó§¡–F–²<e ˜ºÑ@ã!‚GE:øâÚz(Zd
+¡ÏçðÞ·Ò{•ˆY‹å)tì_Ug­	aˆ¤óS).©X   å4òbŽ^À{ãý¯ùÚÎŒ&$.H4`(<*àº¦¸Y8¹…‡H
+ˆ©°ÙððqgBm  ¾ÒM#"Œs[Åz“çŒ®Ú‰ävž„à­·)[Ã7¾ñ¦\ ì   å4µï;¡FÍNéU'KjKŒ1|Èm@PYÑQñŸ>Hˆ«DŽZ¨U£ä‡HÏŽ(\Ã¢}jnÜ×*îáskÙøzZ¥J˜5ó´µ¿*›YŒ½—ß€   õ4
+a^¹ljÊùÉ.ÚõRG]TÁ`±‘¢Â³N&q¢e‘2}×D.&hX("(.ñcA@™[äÿÈÍGoõv1ßŽr»¥ˆ¦ß[˜¾%ÕUÚ‚¡J    Û4@RW3òtûæžºÕDç§F©3BHŒ•>2¥Æ	‘ ¹2ohðÙã"a¤GÅß.1&Ú0¹Y© Ê}qâ|q|#Æ–·ˆÜ«¿ÞP§Kíqé\D€  I4ˆû„#;	{àcN±‘Ç„Ä[GÂƒ«vðÁ@¥Ê6fÙ±>d)®9~jõû•‹YR%!ýrˆÆiùF¹ÈöHæòŠoJy[Êõ@R)"D  S4÷ŸîNFÝ:’ÚÓÔNù‰B_ŸXPPyÑñ ËÃC´ bFNHõûr’%ŠÝˆÊ‰
+O•š:]Jx×h"kyšâF%;«Z™(c‰	ÌÏBÚÞ·NÿÚI)2{‰À  4ò´®¶åëT»éOÒ¾³äS4P ¤à‘ ŠÃ^|»„FD$\¸˜ê2ƒFÄ„ÅØN Ïã,Íl"d±ž°ž8ØŽ·$¸*bB%¦çk`GSbTÔ{   {4ò~ä”+Wø§ŸfgD†„çEœ—™Æ…jŽZà¤d¥Y³bWÅ†nÎSœ™¼1)*”˜¸bF¤€¹”ÓS’LLNÜNc±:Vnhgs“Œû¸ä¦Ô¨H»¬‹L¨  ¶<
+u÷¼¾Ù4Íâ¿-nô%÷­©ÈÑLŽYŒH†glÌtù-¡ÑòÊâ’£õ¢FÂ’Æ"b#³ÂcÆælÓ•/M2§
+Ö¨C¦{œ›àJþ!;w¢×5ƒ{xÓÄ3¹~ÅGÓkñ  74nÌæÃ÷­Tç^íÖ;y³â¬
+>0*22¦Ç‘Ž:<E YB¡""ÃbçCÎ™lua"…&TUAª'ùÏŠ²?WÜv ”wË1-m†$´Ã±‰¸:  °<	¬°ZÑÕ~“æ,ï‘µµ+ú5mÏ§¸&?74)h;âç¢æ$ˆKÜ–—91|à´rÔ°ùñ	ÑË%:Ê…³H.©ÞÃ]©Ì†€žEéÑAØFäà#ØÅ*ezM¨€  ±<Ézy¶¯áÂ²î®;Èj‘ˆ×Š$Á3âAËÊÅ
+›¢8^95%'x J:,&ÖŸ·/dù=Â	¹4dŒ•ÉVªÂ´›Î”^B%¦3iì/vå\~öÈÊÝff  _4»SÊQË9KÈPû;•ÒH(]ð¨H,¼:	œ4©ÙC%ä¬Ê›º2nVí(áËÒ‚±s‚ÄÈ	R©’ÂcUlÛOˆV­}N~—ñ~‡gzÂZ‰ZŒújp.r  84ÖÂS¹ÊW·
+õ žºP¬ø1’Ã&CÀ¨¨ÓÂC"ÐÑÂMÅËŽ¤H.d t¹*äåf¸»‚úõì%v¯)Ì•|b³^„³à'Ž1,&ýš*Ê€   É4dF¾’Ô8î×s'‚±,DÃa†…ç‰„Œ€˜±gâe–8Ø‘“GM“,`d“ÆOoIó3u4©ÛÙŠq¸–“^ý)wV#»ÒÈŒ¯3$ó•,.  H<[ûûcMûæ¿x³ðôOTÂ¬‘s±Q¹˜ˆHd16V;rSÒEÏÄÏ\–#=6xpHXjÜLX&~HbÕB´´*fÐ˜‚…§é<ZF–ñ3b‘LÈC¦€ž“—¥Pg™¤Ôtn   ä4­üÚ•ÁêÙdƒ¡yƒ,4… ÑòG…ÄFaPñW©”>üê2ç›0`TÉR Ê{™‘2ïÌ´7o´Ÿ":¨‘Êì!åÏ…æ´=cÚ&t£Ò–LL¬=`  X4“¡ÿZŸ“>å‘Z‚7@ ÀÐ8
+Œ	†Àè&$9[ƒÄd]•0‘ÐÐ–	ŒÖJV,\Ñóá¯u^ÙÐÍp¥Œ°Lÿ¼--˜+è°gàÎµ¸.ÈÄå
+ý  	4·Ä§QŽ±‰iÚßíÚ‹‘	$Hl5(ƒC¸ 80@DD¡”"×„E…gÏ„ì<`@Mi½áDÚ¶G2œñÊô,Eæ3úñy¹ÿ/Á
+ƒ5}“0  )4§3n…þ&t«»Žw1,ÐóHW›‡RJLáûU¢Dh^;jt…É‘@™ñaú’ÒS$++K¦D&©‰ ¤À†æiiK\#Z]›ÒÌVyov»!8¿³Rò§à  D4«é57J'õškQ¬zúm†KEÃâã!" À\ä"täJÅ«S™4~,v¾`2$(5<9,'=2Eº¨¹tÔDÁZ·Ôr†7r«9”~ckðæäýÉmr¹ŠCër®²  4/ˆ!ÝÈ…Í')Ó¢á+$N¦Ñ3Áa°ŠpÈLøý)1dÜ´©QJ§îÉ',2#|lvùá‹·Æ,ê<›äBe5ŠM½ñŸòê„Ç`Íb—µÂ%‘Ï·EÜeTSÏ€   ý4@RÏ“y•ô_ÄÔ=a“i‘0àe)a‚!Áâ0(LP¡ôN?:*@XðX€À$ëÃ§Žˆ¥(LvbŠZCð…sóCuó“è¬×
+˜JEê©ÅÉ/¿Ü´,ÆÀ  X4©v´J×ÑÏÀŸ„¹Éái×‹¶a0¸¨L(&âçf\§3bRf´Á)ÙêCaÂã“ÖÍ -M5O/¾ÉOÎÜQ£BÍ<.kC”B¼ûÿËm7f’ö  |<dßdÝm4ùÖaaUJ¿Y•¥“¶Žàˆ°øP¬ä©‰óÂ£ÇŒÇE«L£ô2æçfˆT$ºq0è‘‘LýÈ9­êØÅõ‹Ðd¬P‹ÅøQÓ«–ŒMëC"Ð  44¹=%”w(CžøžªWýäÑ6¨±‘@MðDDt|ÈL	±'+D`í³£RÆEâ…Ï‹›®Ôü½üÎ˜hŸrw—»WaëãÑái+¦êWiûKÜ0LoÚTÌ  „<	?ý¤åâ–¿—½–žô4‘!4\´Ì¥˜Œ¸D@^H&QKÒT¢æ.Ü¼&-0v¢~¬Ø˜¼DÍñÓr†ê¨Íø¹¹»‘á~AJ4ÂYJN~">„ctš³55¶\õ ÓôR˜  w<	³Ðù¦çmS¶Ÿ=Z‘$¥åãVæÅì†KHPríÐÁKƒfgnOÎº<'|¬üv¬˜X­™3T7	æ€29ÂQ€z@ÌÿAË±.aêÖ½ù¹vœ½’•óš’éÒ€  Œ<	²ÐÔTæµ¯Ñ{­ú*CSJ‡ÏJ…	†B£AqÕ:#'4<nü€F€J¤ThB+KÈ¿'2xT£éÉ9¯0pÞ£½7´Ö±I°J!Œ%k vOÝ!>ddêýX”Ñ€  ~<™9ù±ßKßý½ùòòNPvÊì¸l‚P,T 3%Ñx‰A1+cb7¯„.EîŽÔÜ….Dj+Mz 4i:«“ÂN›™i]mË®«},möŸHù±÷AûçÜ”GÓ>Ñ¡h  ¦<”g¶™¼VÕ[}ã¯ÖÅµÌÛ’"O…¥Ï‚¦Cº8+xF`TbìÅ`‘±È¥À©¨  "):NBHŽ°ÑÜÝ…½'V»-ÄªÛø+Î	Çµ#çø^ïQ.ï…|üš€  14êÕzØÏÕ¥_s÷x‹N\¨û`Ù‡‚ ‹Ã|66¸AÈÀ»0	¨<P8˜2Yó"2èø¬É;µÊçø5´O'}ˆNøJ#ÎWö«f­&½Å†Ó   ?4	÷Fc©é:¹…yÃZ¾ïMÁ¡'Êˆ&£ º Ë1Ý¯#trØ’r†¬ÎK’M,:3LôŒ@ù+§²F3NððækMü{|Á/ãW¯1ºOÄ15'Šh-0…q€   è4v¬‚ÔfªgCEq#EA2ìò•	Ž<3e‹“MÒg®œ< $É³CaQLŠ<,S`™›}öð¬)ø¯G¬Õ;9˜F¾vâxf?œŽãD´„Œö   41_c9uNÞ{æD!<‰†‰—6"
+”> „‚Ô&ÁÒÃGŽŠ|ÒÀÀa£A#Ëš‘ˆLA—ÞžD5ãÕ]¢·7È¬Bì°åþ,q½W¥tkD@  %4¢/¸•oš¯ÂÖ­„ciÒBØ@>@øt4PlTukÌÔ;f@Z¹‰Câõ„Íšˆ1*&+HæÈèÖd¡ƒ”Â3¤_YE§i…aÙ,jo/Ká>ÔäDð  h<ÕI5i·¡Ëk³¿±&÷Î$.QÖŽVŠ“Æðí¨©[bBW"·¦Ä¥Ä†‚'î¤ÆdG+'`$3"	9û‚×À¬!*	Ü'
+æ	ØÌŒdFb½»î)BlhpR  (4F#kX/ø•˜àØW3eá²Ä%TC¢`ðÅŒ’§lD ‘ Ñ Ùó…FFˆ‡†QEF¶,ÔâÓR@|_+[¯ìŒŸ¡]Æiz·ÂòÜQæõ–rWœ¶pB  4|%)”Ç)KxÕUpY¢ïƒÈÈA#ÇÆ0 >X¢aRäEZž82 pTÐ\p «A–Ú¦šAsÿÈM÷™-ëñfb”Nc#’^àÐŒ—”Éã7ëÀ  "4â­¦æw¡¨#Âö±eÙpi1 P™ððÉðA1‡&*QQ×ÃÁb¯	…ˆ„‡L®/­Ñ4&V&TS	˜¥ÎzÄwRêNß£$ 3jË==*P8Ø  ]4£[Ùy‰:2Ô1ØSJ³,ÆP–ÚÆÁQaÕž2vl°œ”¡“«v36$§Æh%Â5¤è8 N3ÓåÉf#HÏ ÿ99„5<m%òð
+T3ý¼šÓ¯   ?4qîvîšC’X	nWÂœ×8u˜Ù ¸tp$Lpr&g…k‰ªºxr’\íaù±kRƒDä	û'›râ± #°B+eÊ’òT!š‡?–¬á[ÚôLu4ž@  Y4ÂìvœB„÷‘n?§»„e“¤8ñð"|	‚AÂÃ¾"b(“,@dx¦r”^õÀ€x¤¼åÁ™³RVè)IçàPÄÿ—f,7•{7±À;Ë¤UIOð]‹õº·¾æTFñ   4x!¦¥ÜUþÁ;h
+	¡	–
+óÖ"F‹Ë·&RôÀ€‘‰ñ#·…çÉ‹	/SäÔY0@a{8Xì@jÒA‹T#PÆ{B#èý*ôK=*äP  ›<:iªwxµëú‹®&˜[T[>`lÐñ¸™X„NŒäôœv„-
+ÓŸ&#³,"A01#z.:bfˆf„SbSp8R¿¡Y—2-Ðûy»“]KÓˆÈõnç`Ž§²Ñ9GìQ   %4Ò#+à¥¹]»V'G­*¶h,…q£‚áåÆ†Ž0*ñU‚B-’J<d*»sÄ Š—„„Ô0Es¬yGŸ³Bl÷Rô<¥°…Þï÷B¤Ü—BxÌÜ¬_5*¡€  /4nÄG	¯SlÔÅÂ‘„PŠL–0p61÷Î	$.T}¸ÑaV@ŠcÃ‚,$‹n€56dÌ'#!(g²ºÚ©RFRGA(J“ûºÕßEñ™›‡`  4Â¼¯õ*}5Kš´údN0ÊÔD‹$PðÅ‰ˆ\&HØM›Â˜™0x¨&ùcgÕ¡(™8ê»s?aŽiiz…)]Kk1k•$­yVäzrè–€  4åÄ¾vek÷B½L¼ó&|@àÁÁFÇ†IŒ\É²I–>$Àá Še…Ytp:ÈU’ÁÔ‹EÌlÑRÄò˜óû¸ù;R!±Äî¼¹'fÿÖš¡*Juð  ‚4
+æ´BôÄÑaûu²¯ï÷Š‹„”FàÉ T]ÁÒ—¸µ%|´ÄÀÀÀˆ½úÃògå§&­Þ’—µKvDA>Äâ‘WçZ÷WUoÐYûÔŠŠD8¾êëÕ¾GÙvgå)Ê(l  X4è19Œ;™k¶ìuí^ÍDa1dceG@©À\iñÑ<` l´™ÁÂÖ§%¥nÈ	Üœ²)3#v…sSCBi‡~‘ªW8‡³>z’à=GÉilz3½Z4¨	.ç€  J4Þ-×Qy-cömJE’¸mð™ h"˜h¶0™A‚†<D Dx$Dð 8TðÐ ¤ñ ²#M¸ˆÍNnB,!ˆJo+yBüyZ­Õ€[ŒˆYÚˆÂ—H€  `<
+™ú¡¬õ¾¯•Žçžò}<µZŽÙëÂ!IIq‰±°ú95lÈ¹ aŠKR²Â”“Õ"æçéå+[4^bµTÖ:ˆÜ&-°-½)oCÿÍÓœü-5†âF~Í_,Lå#â  ˜<}Rs”`®éaëO=i«+Û+¾*\$4&š‰ÌÌ‡ý¡y3"UgÅ/Õ™œ•¬½'2·5L@(Gð½’Ù‘lÒŽËÏŒss=W ÄÕ	(–Ñ9º
+èF6	M‹á6j°%  •<
+5ýçYšÊ«u&œ¨BÈµõÛõUg‡¢wcÒSÇƒ·|ÜÝ»÷ÏÉÅèL	
+H#d&$ÄÄÊ—¾&u:¢w1VÓsØu5À ÍêÓ–p¯Å:6ËûšQŒk¢ï@  4R„Bß÷ü¯BÇºÜŸÄ’`ùbÄ€Š¡!@ðˆÈÒ‰:Ô¸"®$„žp.`dd¹ƒkbpñYŽ0sÍå~
+ÙÀ+@BŒœîÆ¥ä‘2“çJb7ö™9  ”<98Ø{”r´ë÷ŒhéD7,0Z9)(JÌC¨¿fx‡XµiKòâÒ@åêQÙ µ™ê“R´¯j
+PÌè¨‰îÁØÐVèæp”Žqš=ÁË[c2	Hùæü÷œØô¨Ô  q<1’zë8¢;¬¢É×A2;¦Uä(ÊËbôbQQ¹ÀìÎØ4^\ð¡ùIAH™©ñX„ŒRz`Ô ø‡káS	àb{çPw˜“Wº¬ÂoÚ$w]Ê¦8Úýó¯¾÷Þ¥Ñl$  D4Skî½9þñFÖR±s(è|&<àll(6"?…%DJ8+%.jZ@à¨ÔØñ!Ú*Ñ<è.ÓL¼DdÝ??Z„÷Äò7;„)ö¶¡5±ÝZiˆÊäžø  +4¢­¬/)õ{x/c$FÙB"†  ÙÓ€AÀXD >k+Ø“-3@HŒì¸­âqrk²SâçEhËËT?¡1K4G”ßêº¬ˆ[ ¶©pU¡³‡»`·âTÖ#Ä  U<Ø}ñE'ãgã.:h9:¶sjdÔ­@­“ð¬Ø¼°à~‰Êœ	U»DzÌ^œ¤ù¡¨€¤èÝ¡IP^û²&3ðPÙ¶ß¤ö£´9~ÿ¸!çmU«a®*œö5EZ¦å"Bð  +4¼˜Èvä¥|òRÍ!xÚ†Â‰6&6.02>Ï–™“¶vð¡±2"§%oÊÞ™:"d†Z—Ûc‰¬há¼‚‘ýü¶”ÜÇ/¨bšø7c²Ó6;‹ 	€  4l7RŒKŠqÛö…ó_wä”ºTYH°0ðÀáQÚc>8„ââeW…EPÉ*26>8ñ‘&R@*^f™8O‚Õ	mËÉ}ùÜj·A{ø|lßÝWzVÂL  4NN-„Õ^áJYìžˆ/]f`xé@ˆáðˆàÔ
+°DH\lòÁ“C®_06àtÉ—	DJ¥3"…Â?Pwj·¸™Û{4!¬ÑÛ1‹sÚÔ °B^p)ð  4äZÞ#\HËòOåÆbmØQÁð]!‘–"¥F(óá7ÉË%,>éã­+š,xŠ­Æ=6GVãQúíûè½¶Æ3%HFgÁ
+RvyÁ:3<­à  4Ô!¿±]/Ñ£ü•™’nmq’BÃ¯ˆ‚†•¸2%OŒ,Èétâ$ƒÆØ:Ðð‰ƒÂÇÕ,àX‚ò‡IMh¢ØWß÷û…oó‘Ê†®Q³åZ¿Ìå’Ëu,l±Ð  f<Ï±™o¿Ëc¯½EjîÒÖWN•Ù<ßãg.ˆJ›’•˜ž&X!="RR+bè€¨"›C$`À'’4Ç¿©b1­–€ÝÉ`Û)Å¥v%«ùÊF2  ‹<	ðý¥¡Ï(ó÷?~\H.‘QV\ŠJÏŒË„M†cÐ¨l’Ð°„€¼Åø©ÁÃCSGåg‚tõIF*¾’4ãÒc:„dHêzÀÖfÆ JfØ¹Ž¢Só5fóæ[qQP  Ä<Ü_ÒUVx Ñ2È_Gé*!Sf¡J‘iÉ€àL°~Š„©S›¸0¥ˆ’Ý‰–ß›Ü–»¾^`õ›DÃ
+1G¸Œê×áªMÃ›Ôþ‚t?g7ÈJŒw3Ûþ™"6”€  C4äJCHþÁž%(ëO<„æ™DvP
+„Bá@Â³¿~œ´…ÒÖê[›žšOŒS›+rhØ‰rúJ&4rÇ¹ó[Ÿ«^%€^WÀg£Ö0ðz¼îëf•	Q\R@  m<
+2UYá°ùw¬«Þ8XY-HrÕˆÌø”NB1´ÓÅ'ÈjÉ‹È5—º£³%409£6#MnÙò6„C@ãÉÕþñê€^G	"W¬Eg±V”	õvŸXàR~)€  =4'fÜFz~¸CŒ¿á9xÃÎGŸ$4‡N ¹áý&~ÄÑ+d†È'œ>9"15&:dÄµ¹ÚÎHÍ¶É'[Â¼ƒ×ô¹D1Äü/n°!#Ï—*Xß/Ls.u0  9<–ó+¦«Àû†šP”Þ¯ðT¼½X™À¨LøL!,"Â'ŠKŠ—®)ª;vfH21^väˆ‘Ò,k_Ì@™#8›ø_ÀBˆ'v˜FB”%)Ü#ýºœZ³Å7,Üð\  Y<XRK1TÙéßÓ+Ý‹o\»ˆW¾2
+G@J"KbìÄ‰ûÕá"#££R#‡çÌÌÓ (!"™£M½ íÚ`Îs÷Ém`¤î`Å«6þ£/ÿÞ7vj¨xZ  f<û‰þÒRø·÷O³+,Þ!fZÀ œb)~+%ŸÙÙ
+I	»b·-Oœ	–„d‚ÆïD	û65&™wˆ²Ì'LÆ%?h”àÇ6r\ß–òRžÔ©.:XD  S<èŒjþSUmÈ"Å˜“âÊ{rµÒMB&…ÆçÇoÈÇz|ÀôQêŸÇ¦Äç¯fdÎRÉÊH)pŽj:ºc9 ¤,ûR½ôµBóYyJòè¶ää‚4$  4VNN¹ZxÕÜž.œx mQc ¡ÑñðX>¼ì
+Ï¾hX¼©û´ç%äqK”¦åeŸ¶l¥bõÊfPI6©U9lœ¤#˜NCØRžsq¿ÈØÅMÜÞND€  Ã<	$»­°K·M;b*øÞ–ˆö"DN´—Š&#QD?$aÊb!ñ ÕTâD5^3tð&#Lº|Õy„è„ªÅÜÄ”æ¾;ÚZô®–mrû2äÊs²U~T˜eM†‡   U<ßóá-çAC§Õ-‘Gr$RKOÓÊÛ„IN££jT¬”X’Ô€¸Í(±cÃ¥¥­ÄB5Bô{ŽQW*n–fH¨o ÌÀGbÃ±ß#4½„vâÐÄœKpo•6PÜ¥ {€  4Ðb[(Cejå?â¶XX]hIñð˜¹€Hé°mÁ–( tÓâåA¡GË§	œ(|&Peá!qb¦ÞD»ÐÕCv€­5&òî„zÍðìÎ˜s1wÁ>v)2ŽÛp   _4£CŠ:W€ê†îï¾Šfù¥Ü*p¹1!'O'k^€
+,WXHL½)
+â¦ŒHIH%,n‰=;Eslâ4{Ã·¹
+ízG.áêÈ{|>Ò[ú†å7lI4…   ó<	­+>Úk‘ø¢ ©Ä÷úQ-ùÓY‘ø¤Z;‰ã¸œÎŽÊÎE-Æ¥§åâ!áÁ ¸ütÜF~ZVíSÃ!Õ|h÷fW©ýU]ñ¬§€ Â]Ö’ßâ¹æ²Zz­rn„+¦Íq„€  ÒDÚ]š—£aßùç b5`;}+MëO¤ÃI ¬m8Eã	ü„ó)0ÄO+“
+ÄR™•„ôA-‘Â1=¼Úa?0™JäGæ„¦‚@ï*•ñÎGÒæžækòAss6£šÊ?Ïk¾ZÉ)©è9=4Ë   ÒD=š—£aãõêýÄjÀrö2V›ÖŸI†’!hÚp?Œ'²Ì¤Ã<®L+JfVÑ¶D/ÄöóxüÂb-_[š	¼¨zWÇ9‹Z{™¯ÉÍ¬êŽs'ù=ª£¶‘ÑÓÐrzòiM–   Dú+ª›¯iâúò¡b7`;{šlNk„"™È”b9„“q˜J!HÜZ3ËÅ"ù(¬nhHæ"Y˜Q);žŒBk!¸ÄC#5¦5“Ç"§$.ç ›½õTŠsúM}uÓD2ª(–ºžÚ[MWûaÐ.   ÏDª]ª«aãñîýÄnÀnö2V›ÖŸI†’!xÒp?Œ'òÌÄó<®L-JfSÑ¶D/	$ÆóitBa1ˆ/­‰MÜR=+ãœÅÍÌ×ä‚ææsA5•üž×|µ“ÑÓÐo 4€  Ï<
+¥r
+©_†ŽÆ®A€›•˜C:/tz,
+E ¤0‚Qð~By”˜e&Êb)<ÒÂz –È…á$˜Þm.ˆL&R¹õ±) ;Ê‡¥|s‘øµ§¼™|’ZÚÎ¨ç2“ÚïöRz:zäæœá‘°                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                

--- a/fits_files/nso_dkist_headers.txt
+++ b/fits_files/nso_dkist_headers.txt
@@ -302,3 +302,4 @@ VSPMIRPS=              39.2904 / [mm] FoldMirrorPosition
 VSPSPOS =                12.15 / [mm] SlitSelectorPosition                      
 VSPNMAPS=                    1 / TotalMapScans                                  
 VSPMAP  =                    1 / CurrentMapScan                                 
+END

--- a/fits_files/nso_dkist_headers.txt
+++ b/fits_files/nso_dkist_headers.txt
@@ -1,11 +1,39 @@
-XTENSION= 'IMAGE   '                                                            
-BITPIX  =                  -64                                                  
-NAXIS   =                    3                                                  
-NAXIS1  =                  100 / [pix]                                          
-NAXIS2  =                  998 / [pix]                                          
-NAXIS3  =                    1 / [pix]                                          
-PCOUNT  =                    0                                                  
-GCOUNT  =                    1                                                  
+XTENSION= 'BINTABLE'           / binary table extension                         
+BITPIX  =                    8 / array data type                                
+NAXIS   =                    2 / number of array dimensions                     
+NAXIS1  =                   32 / width of table in bytes                        
+NAXIS2  =                  998 / number of rows in table                        
+PCOUNT  =                95968 / number of group parameters                     
+GCOUNT  =                    1 / number of groups                               
+TFIELDS =                    4 / number of fields in each row                   
+TTYPE1  = 'COMPRESSED_DATA'    / label for field 1                              
+TFORM1  = '1PB(114)'           / data format of field: variable length array    
+TTYPE2  = 'GZIP_COMPRESSED_DATA' / label for field 2                            
+TFORM2  = '1PB(0)  '           / data format of field: variable length array    
+TTYPE3  = 'ZSCALE  '           / label for field 3                              
+TFORM3  = '1D      '           / data format of field: 8-byte DOUBLE            
+TTYPE4  = 'ZZERO   '           / label for field 4                              
+TFORM4  = '1D      '           / data format of field: 8-byte DOUBLE            
+ZIMAGE  =                    T / extension contains compressed image            
+ZTENSION= 'IMAGE   '                                                            
+ZBITPIX =                  -64                                                  
+ZNAXIS  =                    3                                                  
+ZNAXIS1 =                  100 / [pix]                                          
+ZNAXIS2 =                  998 / [pix]                                          
+ZNAXIS3 =                    1 / [pix]                                          
+ZPCOUNT =                    0                                                  
+ZGCOUNT =                    1                                                  
+ZTILE1  =                  100 / size of tiles to be compressed                 
+ZTILE2  =                    1 / size of tiles to be compressed                 
+ZTILE3  =                    1 / size of tiles to be compressed                 
+ZCMPTYPE= 'RICE_1  '           / compression algorithm                          
+ZNAME1  = 'BLOCKSIZE'          / compression block size                         
+ZVAL1   =                   32 / pixels per block                               
+ZNAME2  = 'BYTEPIX '           / bytes per pixel (1, 2, 4, or 8)                
+ZVAL2   =                    4 / bytes per pixel (1, 2, 4, or 8)                
+ZNAME3  = 'NOISEBIT'           / floating point quantization level              
+ZVAL3   =                 16.0 / floating point quantization level              
+ZQUANTIZ= 'NO_DITHER'          / No dithering during quantization               
 BUNIT   = 'ct      '                                                            
 DATE    = '2023-04-22T04:10:58.392'                                             
 DATE-BEG= '2022-06-03T18:34:29.559'                                             
@@ -18,8 +46,8 @@ OBSRVTRY= 'Haleakala High Altitude Observatory Site'
 NETWORK = 'NSF-DKIST'                                                           
 INSTRUME= 'VISP    '                                                            
 OBJECT  = 'unknown '                                                            
-CHECKSUM= 'UMSGaMQFVMQFaMQF'   / HDU checksum updated 2023-04-22T04:10:59       
-DATASUM = '550335088'          / data unit checksum updated 2023-04-22T04:10:59 
+CHECKSUM= '9kg8Akd53kd59kd5'   / HDU checksum updated 2023-04-22T04:10:59       
+DATASUM = '2081763389'         / data unit checksum updated 2023-04-22T04:10:59 
                                                                                 
 COMMENT ------------------------------ Telescope -------------------------------
 COMMENT  Keys describing the pointing and operation of the telescope. Including 
@@ -53,7 +81,7 @@ CUNIT3  = 'arcsec  '
 CUNIT1A = 'nm      '                                                            
 CUNIT2A = 'deg     '                                                            
 CUNIT3A = 'deg     '                                                            
-CTYPE1  = 'AWxAV    '                                                            
+CTYPE1  = 'AWAV    '                                                            
 CTYPE2  = 'HPLT-TAN'                                                            
 CTYPE3  = 'HPLN-TAN'                                                            
 CTYPE1A = 'AWAV    '                                                            
@@ -302,4 +330,31 @@ VSPMIRPS=              39.2904 / [mm] FoldMirrorPosition
 VSPSPOS =                12.15 / [mm] SlitSelectorPosition                      
 VSPNMAPS=                    1 / TotalMapScans                                  
 VSPMAP  =                    1 / CurrentMapScan                                 
-END
+ZHECKSUM= 'UMSGaMQFVMQFaMQF'   / HDU checksum updated 2023-04-22T04:10:59       
+ZDATASUM= '550335088'          / data unit checksum updated 2023-04-22T04:10:59 
+END                                                                             
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                

--- a/fits_files/nso_dkist_headers.txt
+++ b/fits_files/nso_dkist_headers.txt
@@ -1,0 +1,304 @@
+XTENSION= 'IMAGE   '                                                            
+BITPIX  =                  -64                                                  
+NAXIS   =                    3                                                  
+NAXIS1  =                  100 / [pix]                                          
+NAXIS2  =                  998 / [pix]                                          
+NAXIS3  =                    1 / [pix]                                          
+PCOUNT  =                    0                                                  
+GCOUNT  =                    1                                                  
+BUNIT   = 'ct      '                                                            
+DATE    = '2023-04-22T04:10:58.392'                                             
+DATE-BEG= '2022-06-03T18:34:29.559'                                             
+DATE-END= '2022-06-03T18:34:29.825'                                             
+TELAPSE =   0.2660001162439585 / [s]                                            
+DATE-AVG= '2022-06-03T18:34:29.692000'                                          
+ORIGIN  = 'National Solar Observatory'                                          
+TELESCOP= 'Daniel K. Inouye Solar Telescope'                                    
+OBSRVTRY= 'Haleakala High Altitude Observatory Site'                            
+NETWORK = 'NSF-DKIST'                                                           
+INSTRUME= 'VISP    '                                                            
+OBJECT  = 'unknown '                                                            
+CHECKSUM= 'UMSGaMQFVMQFaMQF'   / HDU checksum updated 2023-04-22T04:10:59       
+DATASUM = '550335088'          / data unit checksum updated 2023-04-22T04:10:59 
+                                                                                
+COMMENT ------------------------------ Telescope -------------------------------
+COMMENT  Keys describing the pointing and operation of the telescope. Including 
+COMMENT     the FITS WCS keys describing the world coordinates of the array.    
+COMMENT ------------------------------------------------------------------------
+WCSAXES =                    3                                                  
+WCSAXESA=                    3                                                  
+WCSNAME = 'Helioprojective-cartesian'                                           
+WCSNAMEA= 'Equatorial equinox J2000'                                            
+CRPIX1  =   -82.86774961586269 / [pix]                                          
+CRPIX2  =                499.0 / [pix]                                          
+CRPIX3  =    26.91207092114994 / [pix]                                          
+CRPIX1A =   -82.86778489684515 / [pix]                                          
+CRPIX2A =                499.0 / [pix]                                          
+CRPIX3A =    26.90673195834938 / [pix]                                          
+CRVAL1  =              854.231                                                  
+CRVAL2  =   -378.0016001773252                                                  
+CRVAL3  =   -310.0099922384685                                                  
+CRVAL1A =              854.231                                                  
+CRVAL2A =    22.25861366077565                                                  
+CRVAL3A =    71.54760640717045                                                  
+CDELT1  = 0.000999811469978602                                                  
+CDELT2  =   0.2134568481952311                                                  
+CDELT3  =   0.2134568481952311                                                  
+CDELT1A = 0.000999811469978602                                                  
+CDELT2A = 5.92935689431197E-05                                                  
+CDELT3A = 5.92935689431197E-05                                                  
+CUNIT1  = 'nm      '                                                            
+CUNIT2  = 'arcsec  '                                                            
+CUNIT3  = 'arcsec  '                                                            
+CUNIT1A = 'nm      '                                                            
+CUNIT2A = 'deg     '                                                            
+CUNIT3A = 'deg     '                                                            
+CTYPE1  = 'AWxAV    '                                                            
+CTYPE2  = 'HPLT-TAN'                                                            
+CTYPE3  = 'HPLN-TAN'                                                            
+CTYPE1A = 'AWAV    '                                                            
+CTYPE2A = 'DEC--TAN'                                                            
+CTYPE3A = 'RA---TAN'                                                            
+PC1_1   =    7.607822604906501                                                  
+PC1_2   =                  0.0                                                  
+PC1_3   = -0.00036747296713833                                                  
+PC2_1   =  0.03258800664428634                                                  
+PC2_2   =                  0.0                                                  
+PC2_3   =  0.09119427316600115                                                  
+PC3_1   =                  0.0                                                  
+PC3_2   =    1000.188565571669                                                  
+PC3_3   =                  0.0                                                  
+PC1_1A  =   -7.376733469625965                                                  
+PC1_2A  =                  0.0                                                  
+PC1_3A  = -0.02244171841344273                                                  
+PC2_1A  =   -1.864093831036593                                                  
+PC2_2A  =                  0.0                                                  
+PC2_3A  =   0.0883351211080864                                                  
+PC3_1A  =                  0.0                                                  
+PC3_2A  =    1000.188565571669                                                  
+PC3_3A  =                  0.0                                                  
+LONPOLE =                180.0 / [deg]                                          
+LONPOLEA=                180.0 / [deg]                                          
+TAZIMUTH=    76.35481766529557 / [deg] RawTelescopeAzimuthAngle                 
+ELEV_ANG=    36.54532962098321 / [deg] RawTelescopeElevationAngle               
+TELTRACK= 'Standard Differential Rotation Tracking' / TelescopeTrackingMode     
+TTBLANGL=    197.0144008687807 / [deg] TelescopeCoudeTableAngle                 
+TTBLTRCK= 'Fixed coude table angle' / TelescopeCoudeTableTrackingMode           
+DATEREF = '2022-06-03T18:34:29.559'                                             
+OBSGEO-X=   -5466045.256954942 / [m]                                            
+OBSGEO-Y=   -2404388.737412784 / [m]                                            
+OBSGEO-Z=    2242133.887690042 / [m]                                            
+SPECSYS = 'TOPOCENT'                                                            
+VELOSYS =                  0.0                                                  
+OBS_VR  =   -94.64534176238249 / [m s-1]                                        
+WCSVALID=                    T / WCSValidityIndicator                           
+                                                                                
+COMMENT ------------------------------ Datacenter ------------------------------
+COMMENT      Keys generated by the DKIST data center to describe processing     
+COMMENT                 performed, archiving or extra metadata.                 
+COMMENT ------------------------------------------------------------------------
+DSETID  = 'BQKZZ   '                                                            
+POINT_ID= 'BQKZZ   '                                                            
+FRAMEVOL=     2.27700138092041 / [Mbyte]                                        
+PROCTYPE= 'L1      '                                                            
+RRUNID  =                  578                                                  
+RECIPEID=                    1                                                  
+RINSTID =                  350                                                  
+EXTNAME = 'observation'                                                         
+SOLARNET=                    1                                                  
+OBS_HDU =                    1                                                  
+FILENAME= 'VISP_2022_06_03T18_34_29_559_00854231_I_BQKZZ_L1.fits'               
+CADENCE =   0.3282829148595638 / [s]                                            
+CADMIN  =  0.02399992942810059 / [s]                                            
+CADMAX  =    3.071000099182129 / [s]                                            
+CADVAR  =    0.834011691783927 / [s]                                            
+LEVEL   =                    1                                                  
+HEADVERS= '3.5.0   '                                                            
+HEAD_URL= 'https://docs.dkist.nso.edu/projects/data-products/en/v3.5.0'         
+INFO_URL= 'https://docs.dkist.nso.edu'                                          
+CALVERS = '2.0.1   '                                                            
+CAL_URL = 'https://docs.dkist.nso.edu/projects/visp/en/v2.0.1/l0_to_l1_visp.ht&'
+CONTINUE  'ml'                                                                  
+IDSPARID=                  409                                                  
+IDSOBSID=                  444                                                  
+IDSCALID=                  434                                                  
+WKFLNAME= 'l0_to_l1_visp'                                                       
+WKFLVERS= '2.0.1   '                                                            
+                                                                                
+COMMENT ------------------------------- Dataset --------------------------------
+COMMENT     Keys describing the dataset that this FITS file forms a part of.    
+COMMENT ------------------------------------------------------------------------
+DNAXIS  =                    4                                                  
+DNAXIS1 =                 2538 / [pix]                                          
+DNAXIS2 =                  998 / [pix]                                          
+DNAXIS3 =                  490 / [pix]                                          
+DNAXIS4 =                    4 / [pix]                                          
+DTYPE1  = 'SPECTRAL'                                                            
+DTYPE2  = 'SPATIAL '                                                            
+DTYPE3  = 'SPATIAL '                                                            
+DTYPE4  = 'STOKES  '                                                            
+DPNAME1 = 'dispersion axis'                                                     
+DPNAME2 = 'spatial along slit'                                                  
+DPNAME3 = 'raster scan step number'                                             
+DPNAME4 = 'polarization state'                                                  
+DWNAME1 = 'wavelength'                                                          
+DWNAME2 = 'helioprojective latitude'                                            
+DWNAME3 = 'helioprojective longitude'                                           
+DWNAME4 = 'polarization state'                                                  
+DUNIT1  = 'nm      '                                                            
+DUNIT2  = 'arcsec  '                                                            
+DUNIT3  = 'arcsec  '                                                            
+DUNIT4  = ''                                                                    
+DAAXES  =                    2                                                  
+DEAXES  =                    2                                                  
+DINDEX3 =                  490 / [pix]                                          
+DINDEX4 =                    1 / [pix]                                          
+LINEWAV =              854.231                                                  
+WAVEBAND= 'Ca II (854.21 nm)'                                                   
+WAVEUNIT=                   -9                                                  
+WAVEREF = 'Air     '                                                            
+WAVEMIN =    854.3138521265572 / [nm]                                           
+WAVEMAX =    856.8513736373629 / [nm]                                           
+                                                                                
+COMMENT ------------------------------ Statistics ------------------------------
+COMMENT   Statistical information about the data array contained in this FITS   
+COMMENT                                  file.                                  
+COMMENT ------------------------------------------------------------------------
+DATAMIN =  0.05511225546976106                                                  
+DATAMAX =    1.069711649853424                                                  
+DATAMEAN=   0.7919474769881233                                                  
+DATAMEDN=   0.8430040919513452                                                  
+DATARMS =   0.8080610568147634                                                  
+DATAKURT=    2.335709959309551                                                  
+DATASKEW=   -1.477126138763325                                                  
+                                                                                
+COMMENT ------------------------------- DKIST ID -------------------------------
+COMMENT  Unique identifiers for this FITS file and the observation that created 
+COMMENT                                the data.                                
+COMMENT ------------------------------------------------------------------------
+FILE_ID = '94ba9c5fbadf4f26baef48809f9b2ff3' / FileID                           
+DKISTVER= 'Data Model (SPEC-0122) Revision E' / DKISTFITSHeaderVersion          
+OBSPR_ID= 'eid_1_118_opAvoqBr_R002.82591.14499687' / ObservingProgramExecutionID
+EXPER_ID= 'eid_1_118'          / ExperimentID                                   
+PROP_ID = 'pid_1_118'          / ProposalID                                     
+DSP_ID  = 'eid_1_118_opAvoqBr_R002_ipM6wwxZ_dspCtVjmC' / DataSetParametersID    
+IP_ID   = 'id.85572.341432'    / InstrumentProgramExecutionID                   
+HLSVERS = 'Alakai_5-1'         / DKISTSoftwareVersion                           
+NPROPOS =                    1                                                  
+PROPID01= 'pid_1_118'                                                           
+NEXPERS =                    1                                                  
+EXPRID01= 'eid_1_118'                                                           
+                                                                                
+COMMENT --------------------------- DKIST Operations ---------------------------
+COMMENT    Information about this configuration or operations of the facility   
+COMMENT                        when generating this data.                       
+COMMENT ------------------------------------------------------------------------
+OCS_CTRL= 'Auto    '           / OCSControl                                     
+FIDO_CFG= 'OUT_C-M1_C-BS555_C-BS950_C-W1_C-W3' / FIDOConfiguration              
+DSHEALTH= 'GOOD    '           / DataSourceHealthStatus                         
+DSPSREPS=                    1 / DSPSNumberOfRepeats                            
+DSPSNUM =                    1 / DSPSRepeatNumber                               
+LIGHTLVL=    448.6954002173126 / [adu] LightLevel                               
+                                                                                
+COMMENT -------------------------------- Camera --------------------------------
+COMMENT        Keys describing modes and operation of the camera(s) used.       
+COMMENT ------------------------------------------------------------------------
+CAM_ID  = '15:VSC-04533'       / CameraUniqueID                                 
+CAMERA  = 'AndorZyla.03'       / CameraName                                     
+BITDEPTH=                   16 / SensBitsPerPixel                               
+XPOSURE =    48.00811267605634 / [ms] FPAExposureTime                           
+TEXPOSUR=    4.000676056338028 / [ms] CamExposureTime                           
+CAM_FPS =    41.35716748837339 / [Hz] CamFrameRate                              
+CHIPDIM1=                 2560 / [pix] ChipDimensionX                           
+CHIPDIM2=                 2160 / [pix] ChipDimensionY                           
+HWBIN1  =                    1 / [pix] HardwareBinningX                         
+HWBIN2  =                    1 / [pix] HardwareBinningY                         
+SWBIN1  =                    1 / [pix] SoftwareBinningX                         
+SWBIN2  =                    1 / [pix] SoftwareBinningY                         
+NSUMEXP =                   12 / NumRawFramesinFPA                              
+SWNROI  =                    1 / NumOfSWROI                                     
+SWROI1OX=                    0 / [pix] SWROI1OriginX                            
+SWROI1OY=                    0 / [pix] SWROI1OriginY                            
+SWROI1SX=                 2560 / [pix] SWROI1SizeX                              
+SWROI1SY=                 2000 / [pix] SWROI1SizeY                              
+HWNROI  =                    2 / NumOfHWROI                                     
+HWROI1OX=                    0 / [pix] HWROI1OriginX                            
+HWROI1OY=                    0 / [pix] HWROI1OriginY                            
+HWROI1SX=                 2560 / [pix] HWROI1SizeX                              
+HWROI1SY=                 1000 / [pix] HWROI1SizeY                              
+HWROI2OX=                    0 / [pix] HWROI2OriginX                            
+HWROI2OY=                 1160 / [pix] HWROI2OriginY                            
+HWROI2SX=                 2560 / [pix] HWROI2SizeX                              
+HWROI2SY=                 1000 / [pix] HWROI2SizeY                              
+NBIN1   =                    1                                                  
+NBIN2   =                    1                                                  
+NBIN3   =                    1                                                  
+NBIN    =                    1                                                  
+FPABITPX=                   20 / FPABitsPerPixel                                
+                                                                                
+COMMENT ---------------- Polarization Analysis and Calibration -----------------
+COMMENT  Keys describing the configuration of the Gregorian Optical System (GOS)
+COMMENT                                                                         
+COMMENT ------------------------------------------------------------------------
+GOS_STAT= 'open    '           / Upper GOS shutter                              
+LVL3STAT= 'clear   '           / Level 3 (Lamp)                                 
+LAMPSTAT= 'none    '           / Lamp status                                    
+LVL2STAT= 'clear   '           / Level 2 (Polarizer)                            
+POLANGLE= 'none    '           / [deg] Polarizer Angle                          
+LVL1STAT= 'clear   '           / Level 1 (Retarder)                             
+RETANGLE= 'none    '           / [deg] Retarder angle                           
+LVL0STAT= 'FieldStop (2.8arcmin)' / Level 0 (Apeture)                           
+APERTURE= '2.8arcmin'          / [arcmin, arcsec, mm] Aperture Property         
+LGOSSTAT= 'open    '           / Lower GOS shutter                              
+GOS_TEMP=    16.70166015625001 / [C] Upper GOS optics temperature               
+                                                                                
+COMMENT --------------------------- Adaptive Optics ----------------------------
+COMMENT          Keys describing aspects of the adaptive optics system.         
+COMMENT ------------------------------------------------------------------------
+ATMOS_R0=   0.1116264892989071 / [m] HOAOFriedParameter                         
+AO_LOCK =                    T / HOAOLockStatus                                 
+AO_LOCKX=                  0.0 / [arcsec] HOAOLockOffPointingX                  
+AO_LOCKY=                  0.0 / [arcsec] HOAOLockOffPointingY                  
+WFSLOCKX=                  0.0 / [arcsec] LOWFSLockOffPointingX                 
+WFSLOCKY=                  0.0 / [arcsec] LOWFSLockOffPointingY                 
+LIMBRPOS=                  0.0 / [arcsec] LimbSensorRadialSetPos                
+LIMBRATE=               1000.0 / [Hz] LimbSensorRate                            
+                                                                                
+COMMENT --------------------------- Weather Station ----------------------------
+COMMENT    Keys describing information reported by the weather station at the   
+COMMENT                    facility during this observation.                    
+COMMENT ------------------------------------------------------------------------
+WSSOURCE= 'dkist   '           / WeathSource                                    
+WIND_SPD=    4.958944660448225 / [m s-1] WeathWindSpeed                         
+WIND_DIR=    219.0563882913457 / [deg] WeathWindDirection                       
+WS_TEMP =    11.95233890933754 / [C] WeathOutsideTemperature                    
+WS_HUMID=    14.39925363345676 / [10**-2] WeathRelativeHumidity                 
+WS_DEWPT=   -16.21179492029672 / [C] WeathDewPoint                              
+WS_PRESS=    710.0214144384906 / [hPa] WeathBarometricPressure                  
+SKYBRIGT=                 -1.0 / WeathSkyBrightness                             
+                                                                                
+COMMENT --------------------------- VISP Instrument ----------------------------
+COMMENT          Keys specific to the operation of the VISP instrument.         
+COMMENT ------------------------------------------------------------------------
+VSPARMID=                    3 / ArmID                                          
+VSPARMPS=             -20.0786 / [deg] ArmPosition                              
+VSPARMFC=               54.127 / [mm] ArmFocus                                  
+VSPFILT = 'FF01-857_30-25'     / FilterID                                       
+VSPFWVLN=              856.229 / [nm] FilterWavelength                          
+VSPPOLMD= 'observe_polarimetric' / PolarimeterMode                              
+VSPMODID= '0004    '           / ModulatorID                                    
+VSPMOD  = 'continuous'         / ModulationType                                 
+VSPEXPRT=        41.3571674884 / [Hz] ExposureRate                              
+VSPGRTID= 'Newport_316.0_63.40__M20160612_SN3' / GratingID                      
+VSPGRTCN=                316.0 / [mm-1] GratingConstant                         
+VSPGRTBA=                 63.4 / [deg] GratingBlazeAngle                        
+VSPGRTAN=   -65.36539999999999 / [deg] GratingAngle                             
+VSPWID  =               0.2142 / [arcsec] SlitWidth                             
+VSPSLTSS=       0.132675941182 / [mm] SlitSteppingSize                          
+VSPNSTP =                  490 / NumberofSpatialSteps                           
+VSPSTP  =                  489 / CurrentSpatialStep                             
+VSPTPOS =    82.81485000000001 / [mm] SlitTranslationPosition                   
+VSPMIRPS=              39.2904 / [mm] FoldMirrorPosition                        
+VSPSPOS =                12.15 / [mm] SlitSelectorPosition                      
+VSPNMAPS=                    1 / TotalMapScans                                  
+VSPMAP  =                    1 / CurrentMapScan                                 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,13 @@
+cradle:
+  cabal:
+    - path: "src"
+      component: "lib:fits-parse"
+
+    - path: "examples/omnibus/Main.hs"
+      component: "fits-parse:exe:omnibus"
+
+    - path: "examples/omnibus/Paths_fits_parse.hs"
+      component: "fits-parse:exe:omnibus"
+
+    - path: "test"
+      component: "fits-parse:test:fits-tests"

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,6 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-      - data-default
       - containers
       - text
       - megaparsec

--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ library:
   source-dirs: src
   dependencies:
       - data-default
+      - containers
       - text
       - megaparsec
       - text-latin1
@@ -58,8 +59,10 @@ tests:
     main: Spec.hs
     dependencies:
     - fits-parse
+    - containers
     - tasty
     - tasty-hunit
+    - text
     - megaparsec
     - mtl
 

--- a/package.yaml
+++ b/package.yaml
@@ -50,3 +50,14 @@ executables:
     - fast-logger
     - vector
     - statistics
+
+
+tests:
+  fits-tests:
+    source-dirs: test
+    main: Spec.hs
+    dependencies:
+    - fits-parse
+    - tasty
+    - tasty-hunit
+

--- a/package.yaml
+++ b/package.yaml
@@ -60,4 +60,6 @@ tests:
     - fits-parse
     - tasty
     - tasty-hunit
+    - megaparsec
+    - mtl
 

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -12,7 +12,7 @@ Definitions for the data types needed to parse an HDU in a FITS block.
 {-# LANGUAGE PartialTypeSignatures, DataKinds, ExistentialQuantification
   , ScopedTypeVariables, GADTs
   , GeneralizedNewtypeDeriving
-  , OverloadedRecordDot
+  , OverloadedRecordDot, NoFieldSelectors
   , OverloadedStrings, TypeOperators, TypeFamilies #-}
 module Data.Fits
     ( -- * Data payload functions
@@ -25,7 +25,9 @@ module Data.Fits
     , Pix(..)
 
       -- ** Header Data Types
-    , Header
+    , Header(..)
+    , Data.Fits.lookup
+    , Data.Fits.size
     , Keyword(..)
     , Value(..)
     , LogicalConstant(..)
@@ -53,6 +55,7 @@ import qualified Data.Text as T
 ---- bytestring
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map as Map
 
 import Data.String (IsString)
 
@@ -256,7 +259,14 @@ pixDimsByRow = reverse . pixDimsByCol
     metadata, but also specifying how to make sense of the binary payload
     that starts 2,880 bytes after the start of the 'HeaderData'.
 -}
-type Header = Map Keyword Value
+newtype Header = Header (Map Keyword Value)
+    deriving (Show, Eq)
+
+lookup :: Keyword -> Header -> Maybe Value
+lookup k (Header m) = Map.lookup k m
+
+size :: Header -> Int
+size (Header m) = Map.size m
 
 newtype Keyword = Keyword Text
     deriving (Show, Eq, Ord, IsString)

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -12,7 +12,7 @@ Definitions for the data types needed to parse an HDU in a FITS block.
 {-# LANGUAGE PartialTypeSignatures, DataKinds, ExistentialQuantification
   , ScopedTypeVariables, GADTs
   , GeneralizedNewtypeDeriving
-  , OverloadedRecordDot, NoFieldSelectors
+  , NoFieldSelectors
   , OverloadedStrings, TypeOperators, TypeFamilies #-}
 module Data.Fits
     ( -- * Data payload functions
@@ -260,7 +260,26 @@ pixDimsByRow = reverse . pixDimsByCol
     that starts 2,880 bytes after the start of the 'HeaderData'.
 -}
 newtype Header = Header (Map Keyword Value)
-    deriving (Show, Eq)
+    deriving (Eq)
+
+instance Show Header where
+  show (Header m) =
+    let kvs = Map.toList m :: [(Keyword, Value)]
+    in T.unpack $ T.intercalate "\n" $ fmap line kvs
+    where
+      line :: (Keyword, Value) -> Text
+      line (Keyword k, v) =
+        T.justifyLeft 8 ' ' k
+        <> "="
+        <> T.justifyLeft (hduRecordLength - 10) ' ' (T.pack $ val v)
+
+      val (Integer n) = show n
+      val (Float f) = show f
+      val (Logic T) = "              T"
+      val (String t) = T.unpack t
+
+
+    
 
 lookup :: Keyword -> Header -> Maybe Value
 lookup k (Header m) = Map.lookup k m

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -39,6 +39,7 @@ module Data.Fits
     , isBitPixInt
     , isBitPixFloat
     , bitPixToWordSize
+    , bitPixToByteSize
 
       -- ** Constants
     , hduRecordLength

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -269,12 +269,12 @@ instance Show Header where
     let kvs = Map.toList h.keywords :: [(Keyword, Value)]
     in T.unpack $ T.intercalate "\n" $ fmap line kvs
     where
-
-      init :: [Text]
-      init = map T.pack
-        [ "BITPIX =" <> show h.size.bitpix
-        , "NAXES  =" <> show h.size.naxes
-        ]
+      --
+      -- init :: [Text]
+      -- init = map T.pack
+      --   [ "BITPIX =" <> show h.size.bitpix
+      --   , "NAXES  =" <> show h.size.naxes
+      --   ]
 
       line :: (Keyword, Value) -> Text
       line (Keyword k, v) =
@@ -354,7 +354,7 @@ newtype Comment = Comment Text
 -}
 data HeaderDataUnit = HeaderDataUnit
     { 
-    -- ^ All keywords in the header
+    -- ^ The heeader contains metadata about the payload
       header :: Header
 
       -- ^ The actual data payload

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -27,6 +27,7 @@ module Data.Fits
 
       -- ** Header Data Types
     , Header(..)
+    , UnitType(..)
     , Data.Fits.lookup
     , Keyword(..)
     , Value(..)
@@ -262,6 +263,7 @@ pixDimsByRow = reverse . pixDimsByCol
 data Header = Header
     { keywords :: Map Keyword Value
     , size :: SizeKeywords
+    , unitType :: UnitType
     } deriving (Eq)
 
 instance Show Header where
@@ -287,11 +289,20 @@ instance Show Header where
       val (Logic T) = "              T"
       val (String t) = T.unpack t
 
-
-    
-
 lookup :: Keyword -> Header -> Maybe Value
-lookup k (Header m _) = Map.lookup k m
+lookup k (Header m _ _) = Map.lookup k m
+
+data UnitType
+    -- | Any header data unit can use the primary format. The first MUST be
+    = Primary
+
+    -- | An encoded image. PCOUNT and GCOUNT are required but irrelevant
+    | Image
+
+    -- | A Binary table. PCOUNT is the number of bytes that follow the data
+    -- in the 'heap'
+    | BinTable { pCount :: Int }
+    deriving (Show, Eq)
 
 newtype Keyword = Keyword Text
     deriving (Show, Eq, Ord, IsString)

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -61,9 +61,6 @@ import qualified Data.Map as Map
 
 import Data.String (IsString)
 
----- base
-import Numeric.Natural ( Natural )
-
 ---- ghc
 import GHC.TypeNats (KnownNat, Nat)
 
@@ -115,7 +112,7 @@ data SimpleFormat = Conformant
                     -- ^ Value of SIMPLE=F in the header. /unsupported/
 
 -- | 'Axes' represents the combination of NAXIS + NAXISn. The spec supports up to 999 axes
-newtype Axes = Axes [Natural]
+newtype Axes = Axes [Int]
     deriving (Semigroup, Monoid, Show, Eq)
 
 {-| The 'BitPixFormat' is the nitty gritty of how the 'Axis' data is layed
@@ -143,7 +140,7 @@ instance Show BitPixFormat where
 {-| This utility function can be used to get the word count for data in an
     HDU.
 -}
-bitPixToWordSize :: BitPixFormat -> Natural
+bitPixToWordSize :: BitPixFormat -> Int
 bitPixToWordSize EightBitInt       = 8
 bitPixToWordSize SixteenBitInt     = 16
 bitPixToWordSize ThirtyTwoBitInt   = 32
@@ -154,7 +151,7 @@ bitPixToWordSize SixtyFourBitFloat = 64
 {-| This utility function can be used to get the size in bytes of the
 -   format.
 -}
-bitPixToByteSize :: BitPixFormat -> Natural
+bitPixToByteSize :: BitPixFormat -> Int
 bitPixToByteSize EightBitInt       = 1
 bitPixToByteSize SixteenBitInt     = 2
 bitPixToByteSize ThirtyTwoBitInt   = 4
@@ -241,13 +238,13 @@ parsePix c bpf bs = return $ runGet (getPixs c bpf) bs
 {- `pixDimsByCol` takes a list of Axis and gives a column-row major list of
     axes dimensions.
 -}
-pixDimsByCol :: Axes -> [Natural]
+pixDimsByCol :: Axes -> [Int]
 pixDimsByCol (Axes as) = as
 
 {- `pixDimsByRow` takes a list of Axis and gives a row-column major list of
     axes dimensions.
 -}
-pixDimsByRow :: Axes -> [Natural]
+pixDimsByRow :: Axes -> [Int]
 pixDimsByRow = reverse . pixDimsByCol
 
 {-| The header part of the HDU is vital carrying not only authorship

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -102,6 +102,7 @@ parseKeywordValue = do
     key <- parseKeyword
     parseEquals
     val <- parseValue
+    -- traceM $ show key <> " = " <> show val
     return (key, val)
 
 parseInlineComment :: Int -> Parser Comment

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -302,8 +302,7 @@ parseHeader = do
     -- this consumes all the way up to the end of the header
     -- TODO: handle simple vs image xtension, etc. Each is required differently
     void parseExtension <|> void parseSimple
-
-    sz <- parseSizeKeywords
+    sz <- M.lookAhead parseSizeKeywords
     kvs <- parseAllKeywords
     return $ Header { size = sz, keywords = kvs }
   
@@ -346,7 +345,3 @@ instance Show FitsError where
     show (ParseError e) = displayException e
 
 
-
--- 1st. Which dataset can we do. Put it where they can use it
--- 2nd. When they have made a L2 data product. How do we get that back in such a way that we can put it on the protal
--- 3rd. Make the middle part automatic.

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -14,12 +14,16 @@ Parsing rules for an HDU in a FITS file.
 
 module Data.Fits.MegaParser where
 
+import Debug.Trace
+
 -- qualified imports
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS ( c2w )
 import qualified Text.Megaparsec as M
 import qualified Text.Megaparsec.Stream as M
 import qualified Text.Megaparsec.Char as M
+import qualified Text.Megaparsec.Pos as MP
+import qualified Text.Megaparsec.Byte as MB
 import qualified Text.Megaparsec.Char.Lexer as MCL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -46,7 +50,7 @@ import Data.Proxy
 -- local imports
 import Data.Fits
 
-type Parser = Parsec Void Text
+type Parser = Parsec Void ByteString
 type ParseErr = ParseErrorBundle Text Void
 
 data DataUnitValues
@@ -60,27 +64,56 @@ data DataUnitValues
 
 
 
+-- | Consumes ALL header blocks until end, then all remaining space
 parseHeader :: Parser Header
 parseHeader = do
-    pairs <- M.manyTill ( parseKeywordValue <* M.space ) (M.string' "end")
-    pure $ Map.fromList pairs
+    pairs <- M.manyTill parseKeywordRecord (M.string' "end")
+    M.space -- consume space padding all the way to the end of the next 2880 bytes header block
+    return $ Map.fromList pairs
 
 parseKeywordValue :: Parser (Keyword, Value)
 parseKeywordValue = do
     key <- parseKeyword
     parseEquals
     val <- parseValue
-    pure (key, val)
+    -- M.optional M.newline
+    -- M.optional M.eof
+    return (key, val)
+
+parseKeywordRecord :: Parser (Keyword, Value)
+parseKeywordRecord = do
+    start <- parsePos
+    kv <- parseKeywordValue
+    M.space
+    M.optional $ parseComment start
+    M.space
+    return kv
+
+parsePos :: Parser Int
+parsePos = MP.unPos . MP.sourceColumn <$> M.getSourcePos
+
+parseComment :: Int -> Parser Comment
+parseComment start = do
+    M.char '/'
+    M.space
+    com <- parsePos
+    let end = start + 80
+    let rem = end - com
+    c <- M.count rem M.anySingle
+    return $ Comment (T.pack c)
+
+
 
 parseKeyword :: Parser Keyword
 parseKeyword = Keyword <$> parseText
 
 parseValue :: Parser Value
 parseValue = 
-    (M.try $ Float <$> MCL.signed M.space MCL.float) <|>
-    (M.try $ Integer <$> MCL.signed M.space MCL.decimal) <|>
-    (String <$> parseStringValue) <|>
-    (Logic <$> parseLogic)
+    -- try is required here because Megaparsec doesn't automatically backtrack if the parser consumes anything
+    M.try (Float <$> MCL.signed M.space MCL.float)
+    <|> M.try (Integer <$> MCL.signed M.space MCL.decimal)
+    <|> (String <$> parseStringValue)
+    <|> (Logic <$> parseLogic)
 
 parseLogic :: Parser LogicalConstant
 parseLogic = do
@@ -94,29 +127,29 @@ parseText = do
 
 -- | We don't parse simple here, because it isn't required on all HDUs
 parseSizeKeywords :: Header -> Parser SizeKeywords
-parseSizeKeywords ks = do
-    bp <- parseBitPix ks
-    ax <- parseNaxes ks
+parseSizeKeywords kvs = do
+    bp <- parseBitPix kvs
+    ax <- parseNaxes kvs
     return $ SizeKeywords { bitpix = bp, naxes = ax }
 
 requireKeyword :: Keyword -> Header -> Parser Value
-requireKeyword k ks = do
-    case Map.lookup k ks of
+requireKeyword k kvs = do
+    case Map.lookup k kvs of
       Nothing -> fail $ "Missing: " <> show k
       Just v -> return v
             
 
 parseSimple :: Header -> Parser SimpleFormat
-parseSimple ks = do
-    v <- requireKeyword "SIMPLE" ks
+parseSimple kvs = do
+    v <- requireKeyword "SIMPLE" kvs
     case v of
       Logic T -> return Conformant
       _ -> fail "Invalid Keyword: SIMPLE"
 
 
 parseBitPix :: Header -> Parser BitPixFormat
-parseBitPix ks = do
-    bpn <- requireKeyword "BITPIX" ks
+parseBitPix kvs = do
+    bpn <- requireKeyword "BITPIX" kvs
     toBitpix bpn
     where
       toBitpix (Integer 8) = return EightBitInt
@@ -133,16 +166,16 @@ parseAxisCount = M.string' "naxis" >> parseEquals >> parseNatural
 
 
 requireNaxis :: Header -> Parser Int
-requireNaxis ks = do
-    v <- requireKeyword "NAXIS" ks
+requireNaxis kvs = do
+    v <- requireKeyword "NAXIS" kvs
     case v of
       Integer n -> return n
       _ -> fail "Invalid NAXIS header"
 
 
 parseNaxes :: Header -> Parser NAxes
-parseNaxes ks = do
-    n <- requireNaxis ks
+parseNaxes kvs = do
+    n <- requireNaxis kvs
     as <- mapM naxisn (keywords n)
     return $ NAxes as
 
@@ -152,37 +185,39 @@ parseNaxes ks = do
 
       naxisn :: Keyword -> Parser Natural
       naxisn k = do
-        n <- requireKeyword k ks
+        n <- requireKeyword k kvs
         case n of
           (Integer n) -> return (fromIntegral n)
           _ -> fail $ "Invalid: " <> show k
 
-parseBzero :: Parser Int
-parseBzero = M.string' "bzero" >> parseEquals >> parseInteger
+-- TODO: replace these with known headers
 
-parseBscale :: Parser Int
-parseBscale = M.string' "bscale" >> parseEquals >> parseInteger
-
-parseReference :: Parser Text
-parseReference = M.string' "referenc" >> parseEquals >> parseStringValue
-
-parseObserver :: Parser Text
-parseObserver = M.string' "observer" >> parseEquals >> parseStringValue
-
-parseInstrument :: Parser Text
-parseInstrument = M.string' "instrume" >> parseEquals >> parseStringValue
-
-parseTelescope :: Parser Text
-parseTelescope = M.string' "telescop" >> parseEquals >> parseStringValue
-
-parseObject :: Parser Text
-parseObject = M.string' "object" >> parseEquals >> parseStringValue
-
-parseCreator :: Parser Text
-parseCreator = M.string' "creator" >> parseEquals >> parseStringValue
-
-parseDate :: Parser Text
-parseDate = M.string' "date" >> parseEquals >> parseStringValue
+-- parseBzero :: Parser Int
+-- parseBzero = M.string' "bzero" >> parseEquals >> parseInteger
+--
+-- parseBscale :: Parser Int
+-- parseBscale = M.string' "bscale" >> parseEquals >> parseInteger
+--
+-- parseReference :: Parser Text
+-- parseReference = M.string' "referenc" >> parseEquals >> parseStringValue
+--
+-- parseObserver :: Parser Text
+-- parseObserver = M.string' "observer" >> parseEquals >> parseStringValue
+--
+-- parseInstrument :: Parser Text
+-- parseInstrument = M.string' "instrume" >> parseEquals >> parseStringValue
+--
+-- parseTelescope :: Parser Text
+-- parseTelescope = M.string' "telescop" >> parseEquals >> parseStringValue
+--
+-- parseObject :: Parser Text
+-- parseObject = M.string' "object" >> parseEquals >> parseStringValue
+--
+-- parseCreator :: Parser Text
+-- parseCreator = M.string' "creator" >> parseEquals >> parseStringValue
+--
+-- parseDate :: Parser Text
+-- parseDate = M.string' "date" >> parseEquals >> parseStringValue
 
 skipEmpty :: Parser ()
 skipEmpty = void (M.many $ M.satisfy ('\0' ==))
@@ -219,6 +254,20 @@ parseStringValue = do
     return (T.pack ls)
     where quote = '\''
 
+
+parseHDU :: Parser HeaderDataUnit
+parseHDU = do
+    -- this consumes all the way up to the end of the header
+    h <- parseHeader
+    sz <- parseSizeKeywords h
+
+    -- now grab the data array
+    let len = dataSize sz
+    da <- M.takeP (Just ("Data Array of " <> show len <> " Bytes")) len
+    return $ HeaderDataUnit h size da
+
+
+
 -- countHeaderDataUnits :: ByteString -> IO Natural
 -- countHeaderDataUnits bs = fromIntegral . length <$> getAllHDUs bs
 
@@ -229,20 +278,22 @@ parseStringValue = do
 -- getAllHDUs bs = do
 --     (hdu, rest) <- getOneHDU bs
 --     return [hdu]
---
--- --    if BS.length rest < hduBlockSize then return [hdu] else return [hdu]
--- getOneHDU :: ByteString -> IO (HeaderDataUnit, ByteString)
--- getOneHDU bs =
---     if isAscii header
---       then
---         case M.runParser headerBlockParse "FITS" (TE.decodeUtf8 header) of
---           Right mainHeader -> do
---             let (dataUnit, remainder) = BS.splitAt (fromIntegral $ dataSize mainHeader) rest
---             return (HeaderDataUnit mainHeader dataUnit, remainder)
---           Left e -> let err = M.errorBundlePretty e in error err
---       else error "Header data is not ASCII. Please Check your input file and try again"
---   where
---     (header, rest) = BS.splitAt hduBlockSize bs
+
+--    if BS.length rest < hduBlockSize then return [hdu] else return [hdu]
+getOneHDU :: ByteString -> IO (HeaderDataUnit, ByteString)
+getOneHDU bs =
+    if isAscii header
+      then
+        case M.runParser parseHeaderSize "FITS" (TE.decodeUtf8 header) of
+          Right (mainHeader, size) -> do
+            let (dataUnit, remainder) = BS.splitAt (fromIntegral $ dataSize size) rest
+            return (HeaderDataUnit mainHeader size dataUnit, remainder)
+          Left e -> let err = M.errorBundlePretty e in error err
+      else error "Header data is not ASCII. Please Check your input file and try again"
+  where
+    -- TODO: this won't work. headers can span multiple blocks
+    -- can we consume the ByteString directly?
+    (header, rest) = BS.splitAt hduBlockSize bs
 
 dataSize :: SizeKeywords -> Natural
 dataSize h = wordSize * wordCount

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -31,7 +31,6 @@ import qualified Data.Map.Lazy as Map
 import Control.Applicative ( (<$>) )
 import Control.Monad ( void, foldM )
 import Control.Exception ( Exception(displayException) )
-import Numeric.Natural ( Natural )
 import Data.Bifunctor ( first )
 import Data.ByteString ( ByteString )
 import Data.Char ( ord )
@@ -231,7 +230,7 @@ parseNaxes = do
     return $ Axes ax
 
     where
-      parseN :: Int -> Parser Natural
+      parseN :: Int -> Parser Int
       parseN n = withComments $ do
         M.string' "NAXIS"
         M.string' $ BS.pack $ map toWord (show n)
@@ -292,7 +291,7 @@ parseHDUs :: Parser [HeaderDataUnit]
 parseHDUs = do
     M.many parseHDU
 
-dataSize :: Dimensions -> Natural
+dataSize :: Dimensions -> Int
 dataSize h = size h.bitpix * count h.axes
   where
     count (Axes []) = 0

--- a/src/Data/Fits/Read.hs
+++ b/src/Data/Fits/Read.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Data.Fits.Read where
+
+import Control.Exception ( displayException )
+import Data.Bifunctor ( first )
+import Data.ByteString ( ByteString )
+import Data.Fits as Fits
+import Data.Fits.MegaParser
+import Data.Maybe ( listToMaybe )
+import Data.Text ( Text, unpack )
+import qualified Data.ByteString as BS
+import qualified Data.Map.Lazy as Map
+import qualified Text.Megaparsec as M
+import Data.List ( find )
+
+
+-- | Parse and read all HDUs in the input string
+readHDUs :: ByteString -> Either String [HeaderDataUnit]
+readHDUs bs = do
+    first (show . ParseError) $ M.runParser parseHDUs "FITS" bs
+
+-- | Parse and read only the Primary HDU from the input string
+readPrimaryHDU :: ByteString -> Either String HeaderDataUnit
+readPrimaryHDU bs = do
+    first (show . ParseError) $ M.runParser parseHDU "FITS" bs
+
+-- | Look up a keyword and parse it into the expected format
+getKeyword :: Text -> (Value -> Maybe a) -> HeaderDataUnit -> Either String a
+getKeyword k fromVal hdu = do
+  let key = Keyword k
+  v <- maybeError (MissingKey key) $ Map.lookup key hdu.header.keywords
+  a <- maybeError (InvalidKey key v) $ fromVal v
+  return a
+
+  where
+    findKey :: Keyword -> Header -> Maybe Value
+    findKey key h = Map.lookup key h.keywords
+
+-- | Get the HDU at an index and fail with a readable error
+getHDU :: String -> Int -> [HeaderDataUnit] -> Either String HeaderDataUnit
+getHDU name n hdus = do
+    maybeError (MissingHDU name n) $ listToMaybe $ drop n hdus
+
+maybeError :: FitsError -> Maybe a -> Either String a
+maybeError e Nothing = Left (show e)
+maybeError _ (Just a) = Right a
+
+eitherFail :: MonadFail m => Either String a -> m a 
+eitherFail (Left e) = fail e
+eitherFail (Right a) = return a
+
+data FitsError
+    = ParseError ParseErr
+    | MissingKey Keyword
+    | InvalidKey Keyword Value
+    | MissingHDU String Int 
+    | InvalidData String
+    deriving (Eq)
+
+instance Show FitsError where
+    show (ParseError e) = displayException e
+    show (MissingKey (Keyword k)) = "Keyword Missing: " <> unpack k
+    show (InvalidKey (Keyword k) val) = "Keyword: " <> unpack k <> " was invalid. Got " <> show val
+    show (MissingHDU name n) = "HDU Missing: " <> name <> " at index " <> show n
+    show (InvalidData err) = "Data Invalid: " <> err
+
+
+
+
+
+-- -- | An example of how to use the library
+-- example :: IO ()
+-- example = do
+--     bs <- BS.readFile  "./fits_files/nso_dkist.fits"
+--
+--     (tel, obs, dm) <- throwLeft $ exampleReadMyData bs
+--
+--     putStrLn $ "TELESCOPE: " <> unpack tel
+--     putStrLn $ "OBSERVATORY: " <> unpack obs
+--     putStrLn $ "DATAMIN: " <> show dm
+--
+--   where
+--     throwLeft :: Show e => Either e a -> IO a
+--     throwLeft (Left e) = fail $ show e
+--     throwLeft (Right a) = return a
+--
+--     -- You can parse the file and lookup relevant data in the same function
+--     exampleReadMyData :: ByteString -> Either String (Text, Text, Float)
+--     exampleReadMyData bs = do
+--       hdus <- readHDUs bs
+--       hdu <- getHDU "Main Binary Table" 1 hdus
+--       tel <- getKeyword "TELESCOP" toText hdu
+--       obs <- getKeyword "OBSRVTRY" toText hdu
+--       dm <- getKeyword "DATAMIN" toFloat hdu
+--       return (tel, obs, dm)
+--

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "Hello"
+      [ testCase "TESTING" $ do
+          print "EHLLO"
+          error "FAILED"
+      ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,17 +27,17 @@ import GHC.RTS.Flags (MiscFlags(numIoWorkerThreads))
 main :: IO ()
 main =
   testMain $ runTests "Tests" $ do
-    basicParsing
-    keywordValueLines
-    comments
-    continue
-    fullRecord
-    fullRecordLine
-    headerMap
-    requiredHeaders
-    sampleSpiral
-    sampleNSOHeaders
-    -- sampleNSO
+    -- basicParsing
+    -- keywordValueLines
+    -- comments
+    -- continue
+    -- fullRecord
+    -- fullRecordLine
+    -- headerMap
+    -- requiredHeaders
+    -- sampleSpiral
+    -- sampleNSOHeaders
+    sampleNSO
 
 parse :: Parser a -> ByteString -> IO a
 parse p inp =
@@ -223,6 +223,12 @@ requiredHeaders = describe "required headers" $ do
       res.bitpix @?= ThirtyTwoBitFloat
       res.naxes @?= NAxes [10,20]
 
+    it "should include required headers in the keywords" $ do
+      h <- parse parseHeader $ keywords ["SIMPLE = T", "BITPIX = -32", "NAXIS=2", "NAXIS1=10", "NAXIS2=20", "TEST='hi'"]
+      h.size.naxes @?= NAxes [10,20]
+      Map.size h.keywords @?= 5
+      Map.lookup "NAXIS" h.keywords @?= Just (Integer 2) 
+
 
 sampleSpiral :: Test ()
 sampleSpiral =
@@ -293,8 +299,7 @@ sampleNSO = do
 
       [_, h2] <- pure hdus
 
-      putStrLn "\nHEADER"
-      -- print h2.header
+      print h2.header
 
       Fits.lookup "INSTRUME" h2.header @?= Just (String "VISP")
       Fits.lookup "NAXIS" h2.header @?= Just (Integer 2)
@@ -343,3 +348,16 @@ testMain :: IO TestTree -> IO ()
 testMain mtt = do
     tt <- mtt
     defaultMain tt
+
+
+
+test :: IO ()
+test = do
+    bs <- BS.readFile "./fits_files/nso_dkist_headers.txt"
+    h <- parse parseHeader bs
+    print h
+
+
+
+
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,14 +1,58 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
+import Control.Monad.Writer
+import qualified Data.ByteString as BS
+import Data.Fits.MegaParser
 import Test.Tasty
 import Test.Tasty.HUnit
+import qualified Text.Megaparsec as M
+import qualified Text.Megaparsec.Char as M
 
 main :: IO ()
 main =
-  defaultMain $
-    testGroup
-      "Hello"
-      [ testCase "TESTING" $ do
-          print "EHLLO"
-          error "FAILED"
-      ]
+  defaultMain $ runTests "Tests" $ do
+    basicParsing
+    sampleSpiral
+    sampleNSO
+
+basicParsing :: Test ()
+basicParsing = describe "Basic Parsing" $ do
+  it "should parse simple bzero header" $ do
+    let res = M.runParser parseBzero "Test" "bzero=3"
+    res @?= Right 3
+
+sampleSpiral :: Test ()
+sampleSpiral =
+  describe "Spiral Sample FITS Parse" $ do
+    it "should parse" $ do
+      bs <- BS.readFile "./fits_files/Spiral_2_30_0_300_10_0_NoGrad.fits"
+      hdus <- getAllHDUs bs
+      length hdus @?= 1
+
+sampleNSO :: Test ()
+sampleNSO = do
+  describe "NSO Sample FITS Parse" $ do
+    it "should parse" $ do
+      bs <- BS.readFile "./fits_files/nso_dkist.fits"
+      hdus <- getAllHDUs bs
+      length hdus @?= 1
+
+-- Test monad with describe/it
+newtype Test a = Test {runTest :: Writer [TestTree] a}
+  deriving (Functor, Applicative, Monad, MonadWriter [TestTree])
+
+runTests :: TestName -> Test () -> TestTree
+runTests n (Test t) =
+  let tests = execWriter t :: [TestTree]
+   in testGroup n tests
+
+describe :: TestName -> Test () -> Test ()
+describe n t =
+  tell [runTests n t]
+
+it :: TestName -> IO () -> Test ()
+it n a = do
+  tell [testCase n a]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -273,19 +273,17 @@ sampleNSOHeaders = do
 
       it "should parse all headers individually" $ do
         forM_ ( zip [1..] ts ) $ \(n, t) -> do
-          print ("Header", n, t)
           m <- parse parseHeader $ TE.encodeUtf8 $ t <> "END"
           pure ()
 
       it "should parse NAxes correctly" $ do
         h <- parse parseHeader $ mconcat $ C8.lines bs
-        Fits.lookup "NAXIS" h @?= Just (Integer 3)
-        Fits.lookup "NAXIS1" h @?= Just (Integer 100)
+        Fits.lookup "NAXIS" h @?= Just (Integer 2)
+        Fits.lookup "NAXIS1" h @?= Just (Integer 32)
         Fits.lookup "NAXIS2" h @?= Just (Integer 998)
-        Fits.lookup "NAXIS3" h @?= Just (Integer 1)
 
         sz <- parse (parseSizeKeywords h) ""
-        sz.naxes @?= NAxes [100, 998, 1]
+        sz.naxes @?= NAxes [32, 998]
 
   where
     notContinue = not . T.isPrefixOf "CONTINUE"
@@ -312,10 +310,10 @@ sampleNSO = do
       [_, h2] <- pure hdus
 
       putStrLn "\nHEADER"
-      print h2.header
+      -- print h2.header
 
       Fits.lookup "INSTRUME" h2.header @?= Just (String "VISP")
-      Fits.lookup "NAXIS" h2.header @?= Just (Integer 3)
+      Fits.lookup "NAXIS" h2.header @?= Just (Integer 2)
 
       let sizeOnDisk = 161280
 
@@ -327,8 +325,8 @@ sampleNSO = do
 
       numHeaderBlocks @?= 8
 
-      h2.size.bitpix @?= SixtyFourBitFloat
-      h2.size.naxes @?= NAxes [100, 998, 1]
+      h2.size.bitpix @?= EightBitInt
+      h2.size.naxes @?= NAxes [32, 998]
 
       
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -7,54 +8,94 @@ module Main where
 import Data.Text (Text)
 import Control.Monad.Writer
 import qualified Data.ByteString as BS
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 import Data.Fits.MegaParser
 import Data.Fits
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified Text.Megaparsec as M
 import qualified Text.Megaparsec.Char as M
+import Control.Exception (Exception(displayException))
 
 main :: IO ()
 main =
   defaultMain $ runTests "Tests" $ do
+    basicParsing
     keywordValueLines
-    -- basicParsing
+    headerMap
+    requiredHeaders
     -- sampleSpiral
     -- sampleNSO
     --
     --
-parse :: Parser a -> Text -> Either ParseErr a
-parse p = M.parse p "Test"
+parse :: Parser a -> Text -> IO a
+parse p inp =
+    case M.parse p "Test" inp of
+        Left e -> fail $ displayException e
+        Right v -> pure v
+
+keywords :: [Text] -> Text
+keywords ts = (T.intercalate "\n" ts) <> "\nEND"
+
 
 keywordValueLines :: Test ()
 keywordValueLines = describe "parse keyword=value" $ do
     it "should parse an integer" $ do
-        parse parseKeywordValue "key=42" @?= Right ("key", Integer 42)
+        res <- parse parseKeywordValue "KEY=42"
+        res @?= ("KEY", Integer 42)
 
     it "should parse a string" $ do
-        parse parseKeywordValue "key='value'" @?= Right ("key", String "value")
+        res <- parse parseKeywordValue "KEY='value'" 
+        res @?= ("KEY", String "value")
 
     it "should absorb spaces" $ do
-        parse parseKeywordValue "key   = 'value'   " @?= Right ("key", String "value")
+        res <- parse parseKeywordValue "KEY   = 'value'   "
+        res @?= ("KEY", String "value")
 
     it "should parse a float" $ do
-        parse parseKeywordValue "key =   44.88 " @?= Right ("key", Float 44.88)
+        res <- parse parseKeywordValue "KEY =   44.88 "
+        res @?= ("KEY", Float 44.88)
 
     it "should parse a negative number" $ do
-        parse parseKeywordValue "key = -44.88" @?= Right ("key", Float ( -44.88 ))
+        res <- parse parseKeywordValue "KEY = -44.88"
+        res @?= ("KEY", Float ( -44.88 ))
+
+    it "should parse a logical constant" $ do
+        res <- parse parseKeywordValue "KEY=     T " 
+        res @?= ("KEY", Logic T)
 
 headerMap :: Test ()
 headerMap = describe "parse all headers" $ do
-    it "should parse a list of headers" $ do
-        let res = parse parseRawHeader "key1='value'\nkey2=42"
-        case res of
-            Left e -> fail (show e)
-            Right hs -> do
-                (Map.lookup "key1" hs) @?= Just (String "value")
-                (Map.lookup "key2" hs) @?= Just (Integer 42)
+    it "should parse single header" $ do
+        res <- parse parseHeader "KEY1='value'\nEND"
+        Map.size res @?= 1
+        Map.lookup "KEY1" res @?= Just (String "value")
 
-    
+    it "should parse multiple headers " $ do
+        res <- parse parseHeader "KEY1='value'\nKEY2=  23 \nEND"
+        Map.size res @?= 2
+        Map.lookup "KEY2" res @?= Just (Integer 23)
+
+requiredHeaders :: Test ()
+requiredHeaders = describe "required headers" $ do
+    it "should parse simple format" $ do
+      res <- parse (parseSimple =<< parseHeader) $ keywords ["SIMPLE=    T"]
+      res @?= Conformant
+
+    it "should parse bitpix" $ do
+      res <- parse (parseBitPix =<< parseHeader) $ keywords ["BITPIX = 16"]
+      res @?= SixteenBitInt
+
+    it "should parse NAxes" $ do
+      res <- parse (parseNaxes =<< parseHeader) $ keywords ["NAXIS = 3", "NAXIS1=1", "NAXIS2=2", "NAXIS3=3"]
+      res @?= NAxes [1,2,3]
+
+    it "should parse size" $ do
+      res <- parse (parseSizeKeywords =<< parseHeader) $ keywords ["NAXIS=2", "NAXIS1=10", "NAXIS2=20", "BITPIX = -32"]
+      res.bitpix @?= ThirtyTwoBitFloat
+      res.naxes @?= NAxes [10,20]
+        
 
         
 
@@ -64,21 +105,21 @@ basicParsing = describe "Basic Parsing" $ do
     let res = M.runParser parseBzero "Test" "bzero=3"
     res @?= Right 3
 
-sampleSpiral :: Test ()
-sampleSpiral =
-  describe "Spiral Sample FITS Parse" $ do
-    it "should parse" $ do
-      bs <- BS.readFile "./fits_files/Spiral_2_30_0_300_10_0_NoGrad.fits"
-      hdus <- getAllHDUs bs
-      length hdus @?= 1
-
-sampleNSO :: Test ()
-sampleNSO = do
-  describe "NSO Sample FITS Parse" $ do
-    it "should parse" $ do
-      bs <- BS.readFile "./fits_files/nso_dkist.fits"
-      hdus <- getAllHDUs bs
-      length hdus @?= 1
+-- sampleSpiral :: Test ()
+-- sampleSpiral =
+--   describe "Spiral Sample FITS Parse" $ do
+--     it "should parse" $ do
+--       bs <- BS.readFile "./fits_files/Spiral_2_30_0_300_10_0_NoGrad.fits"
+--       hdus <- getAllHDUs bs
+--       length hdus @?= 1
+--
+-- sampleNSO :: Test ()
+-- sampleNSO = do
+--   describe "NSO Sample FITS Parse" $ do
+--     it "should parse" $ do
+--       bs <- BS.readFile "./fits_files/nso_dkist.fits"
+--       hdus <- getAllHDUs bs
+--       length hdus @?= 1
 
 -- Test monad with describe/it
 newtype Test a = Test {runTest :: Writer [TestTree] a}


### PR DESCRIPTION
As described in discussion in #1, adds more robust support for many things in order to parse FITS files from the NSO L1 Data Products. 

Since we last spoke I added several things, including full support for BINTABLE, a method to read specific headers, and multiple refactors to better support extensions. Sorry for such a huge PR. Turns out our FITS files used just about every features in the spec!

There are still a few cleanup things to do, comments, formatting, etc, but I thought it would be good to get the PR in. 