### PR TITLE
More flexible types to support alt parsing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,6 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-      - containers
       - text
       - megaparsec
       - text-latin1
@@ -67,7 +66,6 @@ tests:
     main: Spec.hs
     dependencies:
     - fits-parse
-    - containers
     - tasty
     - tasty-hunit
     - text

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -132,11 +132,6 @@ data SimpleFormat = Conformant | NonConformant
 data LogicalConstant = T | F
     deriving (Show, Eq)
 
--- {-| The `Text` wrapper for HDU the keyword data for lines of the form:
---     KEYWORD=VALUE
--- -}
--- newtype Keyword = Keyword Text
---     deriving (Show, Eq, Ord, IsString)
 
 {-| `Value` datatype for discriminating valid FITS KEYWORD=VALUE types in an HDU. -}
 data Value
@@ -147,6 +142,9 @@ data Value
     deriving (Show, Eq)
 
 
+{-| A single 80 character header keyword line of the form: KEYWORD = VALUE / comment
+    KEYWORD=VALUE
+-}
 data KeywordRecord = KeywordRecord
   { _keyword :: Text
   , _value :: Value
@@ -155,11 +153,12 @@ data KeywordRecord = KeywordRecord
   deriving (Show, Eq)
 $(makeLenses ''KeywordRecord)
 
--- {-| Headers contain lines that are any of the following
---     KEYWORD =VALUE / inline comment
---     COMMENT this is a comment
---     (blank)
--- -}
+{-| Headers contain lines that are any of the following
+
+ > KEYWORD = VALUE / inline comment
+ > COMMENT full line comment
+ > (blank)
+-}
 data HeaderRecord
     = Keyword KeywordRecord
     | Comment Text

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -164,13 +164,6 @@ data HeaderRecord
     | Comment Text
     | BlankLine
     deriving (Show, Eq)
-
-
-
-
- 
-
-
 {-| 'Axes' represents the combination of NAXIS + NAXISn. The spec supports up to 999 axes -}
 type Axes = [Int]
 

--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -33,6 +33,7 @@ module Data.Fits
     , Header(..)
     , keywords -- ^ get only keywords
     , records -- ^ access all header records
+    , getKeywords
     , HeaderRecord(..)
     , KeywordRecord(..)
     , Extension(..)
@@ -310,17 +311,20 @@ pixDimsByRow = reverse . pixDimsByCol
     that starts 2,880 bytes after the start of the 'HeaderData'.
 -}
 newtype Header = Header { _records :: [HeaderRecord] }
-    deriving (Eq)
+    deriving (Eq, Semigroup, Monoid)
 $(makeLenses ''Header)
+
 
 keywords :: SimpleGetter Header [(Text, Value)]
 keywords = to getKeywords
-  where
-    getKeywords :: Header -> [(Text, Value)]
-    getKeywords h = mapMaybe toKeyword $ h ^. records
 
+
+getKeywords :: Header -> [(Text, Value)]
+getKeywords h = mapMaybe toKeyword $ h ^. records
+  where
     toKeyword (Keyword (KeywordRecord k v _)) = Just (k,v)
     toKeyword _ = Nothing
+
 
 instance Show Header where
   show h =

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -18,10 +18,9 @@ module Data.Fits.MegaParser where
 ---- bytestring
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS ( c2w )
----- containers
-import qualified Data.Map.Lazy as Map
 ---- megaparsec
 import qualified Text.Megaparsec as M
+import qualified Text.Megaparsec.Char as MC
 import qualified Text.Megaparsec.Stream as M
 import qualified Text.Megaparsec.Pos as MP
 import qualified Text.Megaparsec.Byte as M
@@ -31,15 +30,13 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 ---- local imports
 import qualified Data.Fits as Fits
-import qualified Data.Text.Encoding as C8
+import qualified Data.ByteString.Char8 as C8
 import qualified Data.Binary as C8
 
 
 -- symbol imports
 ---- bytestring
 import Data.ByteString ( ByteString )
----- containers
-import Data.Map ( Map )
 ---- text
 import Data.Text ( Text )
 ---- megaparsec
@@ -50,7 +47,7 @@ import Lens.Micro ((^.))
 ---- base
 import Control.Applicative ( (<$>) )
 import Control.Exception ( Exception(displayException) )
-import Control.Monad ( void, foldM )
+import Control.Monad ( void, foldM, replicateM_ )
 import Data.Bifunctor ( first )
 import Data.Char ( ord )
 import Data.Maybe ( catMaybes, fromMaybe )
@@ -59,11 +56,11 @@ import Data.Void ( Void )
 ---- local imports
 import Data.Fits
   ( Axes
-  , Comment(Comment)
   , Dimensions(Dimensions)
   , Header(Header)
+  , KeywordRecord(..)
+  , HeaderRecord(..)
   , HeaderDataUnit(HeaderDataUnit)
-  , Keyword(Keyword)
   , BitPixFormat(..)
   , Extension(..)
   , LogicalConstant(..)
@@ -92,65 +89,102 @@ wordsText = TE.decodeUtf8 . BS.pack
 
 
 -- | Consumes ALL header blocks until end, then all remaining space
-parseHeader :: Parser (Map Keyword Value)
+parseHeader :: Parser Header
 parseHeader = do
     pairs <- M.manyTill parseRecordLine (M.string' "end")
     M.space -- consume space padding all the way to the end of the next 2880 bytes header block
-    return $ Map.fromList $ catMaybes pairs
+    return $ Header pairs
 
-parseRecordLine :: Parser (Maybe (Keyword, Value))
+parseRecordLine :: Parser HeaderRecord
 parseRecordLine = do
-    M.try $ Just <$> parseKeywordRecord
-    <|> Nothing <$ parseLineComment
-    <|> Nothing <$ M.string' (BS.replicate hduRecordLength (toWord ' '))
+    M.try (Keyword <$> parseKeywordRecord)
+      <|> M.try (Comment <$> parseLineComment)
+      <|> BlankLine <$ parseLineBlank
 
--- | Combinator to allow for parsing a record with inline comments
-withComments :: Parser a -> Parser a
-withComments parse = do
-    start <- parsePos
-    a <- parse
-    M.space
-    M.optional $ parseInlineComment start
-    M.space
-    return a
 
-parseKeywordRecord :: Parser (Keyword, Value)
-parseKeywordRecord = withComments parseKeywordValue
+parseKeywordRecord :: Parser KeywordRecord
+parseKeywordRecord = do
+    ((k, v), mc) <- withComments parseKeywordValue
+    pure $ KeywordRecord k v mc
 
 -- | Parses the specified keyword
 parseKeywordRecord' :: ByteString -> Parser a -> Parser a
-parseKeywordRecord' k pval = withComments $ do
+parseKeywordRecord' k pval = ignoreComments $ do
     M.string' k
     parseEquals
     pval
 
-parseKeywordValue :: Parser (Keyword, Value)
+
+
+
+-- | Combinator to allow for parsing a record with inline comments
+withComments :: Parser a -> Parser (a, Maybe Text)
+withComments parse = do
+    -- assumes we are at the beginning of the line
+    lineStart <- parsePos
+    a <- parse
+    mc <- parseLineEnd lineStart
+    return (a, mc)
+
+ignoreComments :: Parser a -> Parser a
+ignoreComments parse = do
+    (a, _) <- withComments parse
+    pure a
+
+
+parseKeywordValue :: Parser (Text, Value)
 parseKeywordValue = do
     key <- parseKeyword
     parseEquals
     val <- parseValue
     return (key, val)
 
-parseInlineComment :: Int -> Parser Comment
-parseInlineComment start = do
-    M.char $ toWord '/'
-    M.space
-    com <- parsePos
-    let end = start + hduRecordLength
-    let rem = end - com
-    c <- M.count rem M.anySingle
-    return $ Comment (wordsText c)
 
-parseLineComment :: Parser Comment
+parseLineEnd :: Int -> Parser (Maybe Text)
+parseLineEnd lineStart = do
+  M.try (Nothing <$ spacesToLineEnd lineStart) <|> (Just <$> parseInlineComment lineStart)
+
+
+spacesToLineEnd :: Int -> Parser ()
+spacesToLineEnd lineStart = do
+  curr <- parsePos
+  let used = curr - lineStart
+  parseSpacesN (hduRecordLength - used)
+  pure ()
+
+parseSpacesN :: Int -> Parser ()
+parseSpacesN n = replicateM_ n (M.char $ toWord ' ')
+
+parseInlineComment :: Int -> Parser Text
+parseInlineComment lineStart = do
+    -- any number of spaces... the previous combinator has eaten up blank lines already
+    M.space
+    M.char $ toWord '/'
+    M.optional charSpace
+    curr <- parsePos
+    let used = curr - lineStart
+    c <- M.count (hduRecordLength - used) M.anySingle
+    return $ T.strip $ wordsText c
+  where
+    charSpace = M.char $ toWord ' '
+
+
+parseLineComment :: Parser Text
 parseLineComment = do
     let keyword = "COMMENT " :: ByteString
     M.string' keyword
     c <- M.count (hduRecordLength - BS.length keyword) M.anySingle
-    return $ Comment (wordsText c)
+    return $ wordsText c
+
+parseLineBlank :: Parser ()
+parseLineBlank = do
+  M.string' (BS.replicate hduRecordLength (toWord ' '))
+  pure ()
+
 
 -- | Anything but a space or equals
-parseKeyword :: Parser Keyword
-parseKeyword = Keyword . wordsText <$> M.some (M.noneOf $ fmap toWord [' ', '='])
+parseKeyword :: Parser Text
+parseKeyword = wordsText <$> M.some (M.noneOf $ fmap toWord [' ', '='])
 
 parseValue :: Parser Value
 parseValue =
@@ -195,7 +229,7 @@ parseStringValue = do
     return (T.stripEnd $ wordsText ls)
     where quote = toWord '\''
 
-requireKeyword :: Keyword -> Header -> Parser Value
+requireKeyword :: Text -> Header -> Parser Value
 requireKeyword k kvs = do
     case Fits.lookup k kvs of
       Nothing -> fail $ "Missing: " <> show k
@@ -243,11 +277,7 @@ parseNaxes = do
     mapM parseN [1..n]
   where
     parseN :: Int -> Parser Int
-    parseN n = withComments $ do
-      M.string' "NAXIS"
-      M.string' $ BS.pack $ map toWord (show n)
-      parseEquals
-      parseInt
+    parseN n = parseKeywordRecord' (C8.pack $ "NAXIS" <> show n) parseInt
 
 -- | We don't parse simple here, because it isn't required on all HDUs
 parseDimensions :: Parser Dimensions
@@ -261,15 +291,15 @@ parsePrimary = do
     dm <- M.lookAhead parseDimensions
     hd <- parseHeader
     dt <- parseMainData dm
-    return $ HeaderDataUnit (Header hd) dm Primary dt
+    return $ HeaderDataUnit hd dm Primary dt
 
 parseImage :: Parser HeaderDataUnit
 parseImage = do
-    withComments $ M.string' "XTENSION= 'IMAGE   '"
+    ignoreComments $ M.string' "XTENSION= 'IMAGE   '"
     dm <- M.lookAhead parseDimensions
     hd <- parseHeader
     dt <- parseMainData dm
-    return $ HeaderDataUnit (Header hd) dm Image dt
+    return $ HeaderDataUnit hd dm Image dt
 
 parseBinTable :: Parser HeaderDataUnit
 parseBinTable = do
@@ -278,13 +308,13 @@ parseBinTable = do
     dt <- parseMainData dm
     hp <- parseBinTableHeap
     let tab = BinTable pc hp
-    return $ HeaderDataUnit (Header hd) dm tab dt
+    return $ HeaderDataUnit hd dm tab dt
     where
       parseBinTableHeap = return ""
 
 parseBinTableKeywords :: Parser (Dimensions, Int)
 parseBinTableKeywords = do 
-  withComments $ M.string' "XTENSION= 'BINTABLE'"
+  ignoreComments $ M.string' "XTENSION= 'BINTABLE'"
   sz <- parseDimensions
   pc <- parseKeywordRecord' "PCOUNT" parseInt
   return (sz, pc)

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -287,19 +287,29 @@ parseDimensions = do
 
 parsePrimary :: Parser HeaderDataUnit
 parsePrimary = do
-    parseKeywordRecord' "SIMPLE" parseLogic
-    dm <- M.lookAhead parseDimensions
+    dm <- parsePrimaryKeywords
     hd <- parseHeader
     dt <- parseMainData dm
     return $ HeaderDataUnit hd dm Primary dt
 
+
+parsePrimaryKeywords :: Parser Dimensions
+parsePrimaryKeywords = do
+    parseKeywordRecord' "SIMPLE" parseLogic
+    M.lookAhead parseDimensions
+
+
 parseImage :: Parser HeaderDataUnit
 parseImage = do
-    ignoreComments $ M.string' "XTENSION= 'IMAGE   '"
-    dm <- M.lookAhead parseDimensions
+    dm <- parseImageKeywords
     hd <- parseHeader
     dt <- parseMainData dm
     return $ HeaderDataUnit hd dm Image dt
+
+parseImageKeywords :: Parser Dimensions
+parseImageKeywords = do
+    ignoreComments $ M.string' "XTENSION= 'IMAGE   '"
+    M.lookAhead parseDimensions
 
 parseBinTable :: Parser HeaderDataUnit
 parseBinTable = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -342,7 +342,7 @@ sampleSpiral =
       hdu <- eitherFail $ readPrimaryHDU bs
       -- hdu.header.size.bitpix @?= ThirtyTwoBitFloat
       -- hdu.header.size.naxes @?= NAxes [621, 621]
-      --
+ 
       Fits.lookup "NAXIS" (hdu ^. header) @?= Just (Integer 2) 
 
       let payloadSize = BS.length (hdu ^. mainData)
@@ -364,8 +364,6 @@ sampleNSOHeaders = do
               ]
       h <- parse parseHeader $ flattenKeywords h
       length (h ^. keywords) @?= 1
-      -- print $ h ^. records
-      -- length (h ^. records) @?= 5
 
 
     describe "sample header file" $ do
@@ -378,15 +376,12 @@ sampleNSOHeaders = do
           pure ()
 
       it "should parse xtension bintable" $ do
-        flip parse bs $ do
-          ignoreComments $ M.string' "XTENSION= 'BINTABLE'"
-          pure ()
-        -- (sz, _) <- parse parseBinTableKeywords $ mconcat $ C8.lines bs
-        -- (sz ^. axes) @?= [32, 998]
+          (sz, _) <- parse parseBinTableKeywords $ mconcat $ C8.lines bs
+          (sz ^. axes) @?= [32, 998]
 
-      -- it "should parse NAXES correctly" $ do
-      --   (sz, _) <- parse parseBinTableKeywords $ mconcat $ C8.lines bs
-      --   (sz ^. axes) @?= [32, 998]
+      it "should parse NAXES correctly" $ do
+        (sz, _) <- parse parseBinTableKeywords $ mconcat $ C8.lines bs
+        (sz ^. axes) @?= [32, 998]
 
   where
     ignore t = T.isPrefixOf "CONTINUE" t || T.isPrefixOf "END" t


### PR DESCRIPTION
Hey @krakrjak! 

I've started a "Telescope" package with a higher-level interface here: https://github.com/dkistdc/telescope.hs. It supports multi-dimensional arrays, and writing FITS files. I had to make a few changes to fits-parse to give more flexibility to the user. They basically boil down to the following:

Change Header from a Map to an Association List: To write FITS files, controlling the order of headers is important. 

```
newtype Header = Header { _records :: [HeaderRecord] }
    deriving (Eq, Semigroup, Monoid)
```

Added richer sub-types to make working with Header/Keywords easier:

```
data KeywordRecord = KeywordRecord
  { _keyword :: Text
  , _value :: Value
  , _comment :: Maybe Text
  }
  deriving (Show, Eq)

data HeaderRecord
    = Keyword KeywordRecord
    | Comment Text
    | BlankLine
    deriving (Show, Eq)
```

Exposing parsers for keywords, not just full HDUs

```
parsePrimaryKeywords :: Parser Dimensions
parsePrimaryKeywords = do
    parseKeywordRecord' "SIMPLE" parseLogic
    M.lookAhead parseDimensions
```

Any thoughts or comments? 