### PR TITLE
Commit cabal file to allow projects to depend on git commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-fits-parse.cabal
 .stack-work/
 .venv
 docs/_build/*

--- a/fits-parse.cabal
+++ b/fits-parse.cabal
@@ -1,0 +1,100 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.36.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           fits-parse
+version:        0.3.6
+synopsis:       Parse FITS files
+description:    Parse and manipulate FITS data natively in Haskell
+category:       Science
+homepage:       https://github.com/krakrjak/fits-parse#readme
+author:         Zac Slade
+maintainer:     Zac Slade <krakrjak@gmail.com>,
+                Sean Hess
+copyright:      Copyright (c) 2023 Zac Slade
+license:        BSD2
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    stack.yaml
+    stack.yaml.lock
+    package.yaml
+    docs/Makefile
+    docs/make.bat
+    docs/conf.py
+    docs/index.rst
+    docs/examples/omnibus.rst
+    fits_files/nso_dkist.fits
+    fits_files/Spiral_2_30_0_300_10_0_NoGrad.fits
+    fits_files/nso_dkist_headers.txt
+    fits_files/nonconformant/testkeys.fits
+    fits_files/nonconformant/testkeys2.fits
+
+flag examples
+  description: Do you want to build the examples?
+  manual: True
+  default: False
+
+library
+  exposed-modules:
+      Data.Fits
+      Data.Fits.MegaParser
+      Data.Fits.Read
+  other-modules:
+      Paths_fits_parse
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , binary
+    , bytestring
+    , megaparsec
+    , microlens
+    , microlens-th
+    , text
+    , text-latin1
+  default-language: Haskell2010
+
+executable omnibus
+  main-is: Main.hs
+  other-modules:
+      Paths_fits_parse
+  hs-source-dirs:
+      examples/omnibus
+  build-depends:
+      JuicyPixels
+    , base >=4.7 && <5
+    , bytestring
+    , fast-logger
+    , fits-parse
+    , microlens
+    , microlens-th
+    , optparse-applicative
+    , statistics
+    , vector
+  default-language: Haskell2010
+  if flag(examples)
+    buildable: True
+
+test-suite fits-tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_fits_parse
+  hs-source-dirs:
+      test
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , fits-parse
+    , megaparsec
+    , microlens
+    , microlens-th
+    , mtl
+    , tasty
+    , tasty-hunit
+    , text
+  default-language: Haskell2010


### PR DESCRIPTION
Remove .cabal file from the .gitignore and commit to the repo. This allows one to depend on github branches via `source-repository-package`

```
-- cabal.project
source-repository-package
  type: git
  location: https://github.com/seanhess/fits-parse.git
  tag: 7828eb88957e2a93ffebf90974523dc4845a0c61
```