### PR TITLE
Value uses Double instead of Float. Fixes #8

### DIFF
--- a/src/Data/Fits.hs
+++ b/src/Data/Fits.hs
@@ -136,7 +136,7 @@ data LogicalConstant = T | F
 {-| `Value` datatype for discriminating valid FITS KEYWORD=VALUE types in an HDU. -}
 data Value
     = Integer Int
-    | Float Float
+    | Float Double
     | String Text
     | Logic LogicalConstant
     deriving (Show, Eq)
@@ -374,7 +374,7 @@ toInt :: Value -> Maybe Int
 toInt (Integer i) = Just i
 toInt _ = Nothing
 
-toFloat :: Value -> Maybe Float
+toFloat :: Value -> Maybe Double
 toFloat (Float n) = Just n
 toFloat _ = Nothing
 

--- a/src/Data/Fits/MegaParser.hs
+++ b/src/Data/Fits/MegaParser.hs
@@ -197,7 +197,7 @@ parseValue =
 parseInt :: Num a => Parser a
 parseInt = MBL.signed M.space MBL.decimal
 
-parseFloat :: Parser Float
+parseFloat :: Parser Double
 parseFloat = MBL.signed M.space MBL.float
 
 parseLogic :: Parser LogicalConstant


### PR DESCRIPTION
Always reads header record floating numbers as 64 bits. 

Motivating Example: The numbers have up to 16 sigificant digits. We don't want to lose precision when we parse these. `Float` can only handle about 7. 
 
```
WCSNAME = 'Helioprojective-cartesian'
WCSNAMEA= 'Equatorial equinox J2000'
CRPIX1  =   -85.86772915846299 / [pix]
CRPIX2  =                477.0 / [pix]
CRPIX3  =    17.52015992216496 / [pix]
```

Should we also rename the constructor `Float` to `Floating` or something similar? 